### PR TITLE
docs: document and test file-destination gzip option

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -160,25 +160,38 @@ conf:
 ---
 
 #### Compressed File Output (gzip)
-**File**: `file_order.yaml`
+
+Set `compress: true` in the `conf` section to write gzip-compressed output. The `.gz` extension is appended automatically — no need to include it in the path.
+
+Supported with **JSON** and **CSV** formats (Avro uses its own internal Deflate codec when `compress: true`).
+
+**File**: `file_customer_gzip.yaml`
 ```yaml
-source: order.yaml
+source: customer.yaml
 type: file
 seed:
   type: embedded
-  value: 54321
+  value: 98765
 conf:
-  path: output/orders
-  compress: true    # Enable gzip compression
+  path: build/run-output/customers
+  compress: true    # Enable gzip compression (.gz added automatically)
   append: false
 ```
 
 **Usage**:
 ```bash
-./gradlew :cli:run --args="execute --job config/jobs/file_order.yaml --format json --count 10000"
+./gradlew :cli:run --args="execute --job config/jobs/file_customer_gzip.yaml --format json --count 1000"
 ```
 
-**Output**: `output/orders.json.gz` (compressed)
+**Output**: `build/run-output/customers.json.gz` (valid gzip, decompresses to newline-delimited JSON)
+
+See `config/jobs/file_order.yaml` for a gzip example with nested structures.
+
+```bash
+# Verify gzip output is valid and round-trips:
+gzip -t build/run-output/customers.json.gz
+zcat build/run-output/customers.json.gz | head -3
+```
 
 ---
 

--- a/config/jobs/file_customer_gzip.yaml
+++ b/config/jobs/file_customer_gzip.yaml
@@ -1,0 +1,9 @@
+source: customer.yaml
+type: file
+seed:
+  type: embedded
+  value: 98765
+conf:
+  path: build/run-output/customers
+  compress: true
+  append: false

--- a/destinations/src/test/java/com/datagenerator/destinations/file/FileDestinationTest.java
+++ b/destinations/src/test/java/com/datagenerator/destinations/file/FileDestinationTest.java
@@ -106,24 +106,36 @@ class FileDestinationTest {
     Path outputFile = tempDir.resolve(OUTPUT_JSON);
     FileDestinationConfig config = configBuilder.filePath(outputFile).compress(true).build();
 
-    Map<String, Object> data = Map.of("name", "John", "age", 42);
+    Map<String, Object> record1 = Map.of("name", "Alice", "age", 30);
+    Map<String, Object> record2 = Map.of("name", "Bob", "age", 25);
+    Map<String, Object> record3 = Map.of("name", "Carol", "age", 28);
 
     try (FileDestination destination = new FileDestination(config, new JsonSerializer())) {
       destination.open();
-      destination.write(data);
+      destination.write(record1);
+      destination.write(record2);
+      destination.write(record3);
     }
 
     // File should have .gz extension
     Path gzFile = Path.of(outputFile.toString() + ".gz");
     assertThat(gzFile).exists();
+    assertThat(Files.size(gzFile)).isGreaterThan(0);
 
-    // Decompress and verify content
+    // Decompress and verify all records round-trip
+    List<String> lines = new ArrayList<>();
     try (BufferedReader reader =
         new BufferedReader(
             new InputStreamReader(new GZIPInputStream(Files.newInputStream(gzFile))))) {
-      String line = reader.readLine();
-      assertThat(line).contains("John");
+      String line;
+      while ((line = reader.readLine()) != null) {
+        lines.add(line);
+      }
     }
+    assertThat(lines).hasSize(3);
+    assertThat(lines.get(0)).contains("Alice").contains("\"age\":30");
+    assertThat(lines.get(1)).contains("Bob").contains("\"age\":25");
+    assertThat(lines.get(2)).contains("Carol").contains("\"age\":28");
   }
 
   @Test


### PR DESCRIPTION
## Description
Document and test the file-destination gzip compression option (closes #106).

## Changes
- **New example job**: `config/jobs/file_customer_gzip.yaml` — a dedicated, minimal gzip example using the customer structure
- **Documentation**: Expanded the "Compressed File Output (gzip)" section in `config/README.md` with usage notes, format support (JSON, CSV), and verification commands
- **Test**: Strengthened `shouldCompressOutputWithGzip` in `FileDestinationTest` to write multiple records and verify exact round-trip content after decompression

## Type of Change
- [x] Documentation update
- [x] New feature (test strengthening)

## Testing
- `./gradlew :destinations:test` — all tests pass, including the enhanced gzip test
- `./gradlew spotlessCheck` — passes

## Checklist
- [x] Code formatted with Spotless
- [x] All tests pass
- [x] Documentation updated
- [ ] CHANGELOG.md updated (N/A — minor doc/test improvement)