### PR TITLE
Handle CLI execution exceptions without raw stack traces

### DIFF
--- a/cli/src/main/java/com/datagenerator/cli/DataGeneratorCli.java
+++ b/cli/src/main/java/com/datagenerator/cli/DataGeneratorCli.java
@@ -49,7 +49,16 @@ import picocli.CommandLine.IVersionProvider;
 public class DataGeneratorCli implements Runnable {
 
   public static void main(String[] args) {
-    int exitCode = new CommandLine(new DataGeneratorCli()).execute(args);
+
+    CommandLine cmd = new CommandLine(new DataGeneratorCli());
+
+    cmd.setExecutionExceptionHandler(
+        (ex, commandLine, parseResult) -> {
+          commandLine.getErr().println(ex.getMessage());
+          return 1;
+        });
+
+    int exitCode = cmd.execute(args);
     System.exit(exitCode);
   }
 

--- a/cli/src/main/java/com/datagenerator/cli/DataGeneratorCli.java
+++ b/cli/src/main/java/com/datagenerator/cli/DataGeneratorCli.java
@@ -52,14 +52,17 @@ public class DataGeneratorCli implements Runnable {
 
     CommandLine cmd = new CommandLine(new DataGeneratorCli());
 
-    cmd.setExecutionExceptionHandler(
-        (ex, commandLine, parseResult) -> {
-          commandLine.getErr().println(ex.getMessage());
-          return 1;
-        });
+    cmd.setExecutionExceptionHandler(friendlyExceptionHandler());
 
     int exitCode = cmd.execute(args);
     System.exit(exitCode);
+  }
+
+  static CommandLine.IExecutionExceptionHandler friendlyExceptionHandler() {
+    return (ex, commandLine, parseResult) -> {
+      commandLine.getErr().println(ex.getMessage());
+      return 1;
+    };
   }
 
   @Override

--- a/cli/src/test/java/com/datagenerator/cli/ExecuteCommandTest.java
+++ b/cli/src/test/java/com/datagenerator/cli/ExecuteCommandTest.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -274,6 +276,31 @@ class ExecuteCommandTest {
   void nonexistentJobFileReturnsError() {
     int code = execute(OPT_JOB, tempDir.resolve("nonexistent.yaml").toString(), OPT_COUNT, "1");
     assertThat(code).isNotZero();
+  }
+
+  @Test
+  void nonexistentJobFileShowsFriendlyErrorMessage() {
+
+    StringWriter err = new StringWriter();
+
+    CommandLine cmd = new CommandLine(new ExecuteCommand());
+
+    cmd.setErr(new PrintWriter(err));
+
+    cmd.setExecutionExceptionHandler(
+        (ex, commandLine, parseResult) -> {
+          commandLine.getErr().println(ex.getMessage());
+          return 1;
+        });
+
+    int code = cmd.execute(OPT_JOB, tempDir.resolve("nonexistent.yaml").toString(), OPT_COUNT, "1");
+
+    String output = err.toString();
+
+    assertThat(code).isNotZero();
+    assertThat(output).contains("nonexistent.yaml");
+    assertThat(output).doesNotContain("SchemaParseException");
+    assertThat(output).doesNotContain("\tat");
   }
 
   @Test

--- a/cli/src/test/java/com/datagenerator/cli/ExecuteCommandTest.java
+++ b/cli/src/test/java/com/datagenerator/cli/ExecuteCommandTest.java
@@ -287,11 +287,7 @@ class ExecuteCommandTest {
 
     cmd.setErr(new PrintWriter(err));
 
-    cmd.setExecutionExceptionHandler(
-        (ex, commandLine, parseResult) -> {
-          commandLine.getErr().println(ex.getMessage());
-          return 1;
-        });
+    cmd.setExecutionExceptionHandler(DataGeneratorCli.friendlyExceptionHandler());
 
     int code = cmd.execute(OPT_JOB, tempDir.resolve("nonexistent.yaml").toString(), OPT_COUNT, "1");
 


### PR DESCRIPTION
## Description

Fixes #104

Previously, missing configuration files resulted in a raw Java stack trace being displayed to the user.

This change adds a Picocli execution exception handler that prints only the exception message, making CLI errors clearer and more user-friendly.

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

* Added a Picocli execution exception handler in `DataGeneratorCli`
* Removed raw stack traces from default CLI output
* Preserved the original error message for missing configuration files

## Testing

* [x] Manual testing performed

**Commands run:**

```bash
./gradlew :cli:test
./gradlew spotlessCheck
```

## Additional Context

Before:

```text
SchemaParseException: job config file not found: does-not-exist.yaml
    at ...
    at ...
```

After:

```text
job config file not found: does-not-exist.yaml
```
