### PR TITLE
fix(security): fail closed on Schema Registry auth misconfiguration (T06)

### DIFF
--- a/formats/src/main/java/com/datagenerator/formats/avro/HttpSchemaRegistryClient.java
+++ b/formats/src/main/java/com/datagenerator/formats/avro/HttpSchemaRegistryClient.java
@@ -28,6 +28,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.extern.slf4j.Slf4j;
 
@@ -159,15 +160,28 @@ public final class HttpSchemaRegistryClient implements SchemaRegistryClient {
 
   private static String buildAuthHeader(String authType, String token) {
     if (authType == null || authType.isBlank()) return null;
-    return switch (authType.toLowerCase(java.util.Locale.ROOT)) {
-      case "bearer" -> token != null ? "Bearer " + token : null;
-      case "basic" ->
-          token != null
-              ? "Basic "
-                  + Base64.getEncoder().encodeToString(token.getBytes(StandardCharsets.UTF_8))
-              : null;
-      case null -> null;
-      default -> null;
+    String normalizedType = authType.toLowerCase(Locale.ROOT);
+    return switch (normalizedType) {
+      case "bearer" -> {
+        requireToken(token, normalizedType);
+        yield "Bearer " + token;
+      }
+      case "basic" -> {
+        requireToken(token, normalizedType);
+        yield "Basic " + Base64.getEncoder().encodeToString(token.getBytes(StandardCharsets.UTF_8));
+      }
+      default ->
+          throw new SchemaRegistryException(
+              "Unsupported schema_registry_auth: '" + authType + "'; supported: bearer, basic");
     };
+  }
+
+  private static void requireToken(String token, String normalizedType) {
+    if (token == null || token.isBlank()) {
+      throw new SchemaRegistryException(
+          "schema_registry_token is required when schema_registry_auth is '"
+              + normalizedType
+              + "'");
+    }
   }
 }

--- a/formats/src/main/java/com/datagenerator/formats/avro/HttpSchemaRegistryClient.java
+++ b/formats/src/main/java/com/datagenerator/formats/avro/HttpSchemaRegistryClient.java
@@ -170,7 +170,7 @@ public final class HttpSchemaRegistryClient implements SchemaRegistryClient {
         requireToken(token, normalizedType);
         yield "Basic " + Base64.getEncoder().encodeToString(token.getBytes(StandardCharsets.UTF_8));
       }
-      default ->
+      case null, default ->
           throw new SchemaRegistryException(
               "Unsupported schema_registry_auth: '" + authType + "'; supported: bearer, basic");
     };

--- a/formats/src/test/java/com/datagenerator/formats/avro/HttpSchemaRegistryClientTest.java
+++ b/formats/src/test/java/com/datagenerator/formats/avro/HttpSchemaRegistryClientTest.java
@@ -235,4 +235,71 @@ class HttpSchemaRegistryClientTest {
         .isInstanceOf(SchemaRegistryException.class)
         .hasMessageContaining("schema_registry_url");
   }
+
+  // ── Auth misconfiguration (fail closed) ──────────────────────────────────
+
+  @Test
+  void throwsWhenAuthTypeIsUnknown() {
+    assertThatThrownBy(() -> new HttpSchemaRegistryClient(REGISTRY_URL, "baerer", "some-token"))
+        .isInstanceOf(SchemaRegistryException.class)
+        .hasMessageContaining("Unsupported schema_registry_auth")
+        .hasMessageContaining("baerer")
+        .hasMessageContaining("bearer, basic")
+        .hasMessageNotContaining("some-token");
+  }
+
+  @Test
+  void throwsWhenBearerAuthConfiguredWithoutToken() {
+    assertThatThrownBy(() -> new HttpSchemaRegistryClient(REGISTRY_URL, "bearer", null))
+        .isInstanceOf(SchemaRegistryException.class)
+        .hasMessageContaining("schema_registry_token is required")
+        .hasMessageContaining("bearer");
+  }
+
+  @Test
+  void throwsWhenBearerAuthConfiguredWithBlankToken() {
+    assertThatThrownBy(() -> new HttpSchemaRegistryClient(REGISTRY_URL, "bearer", "   "))
+        .isInstanceOf(SchemaRegistryException.class)
+        .hasMessageContaining("schema_registry_token is required")
+        .hasMessageContaining("bearer");
+  }
+
+  @Test
+  void throwsWhenBasicAuthConfiguredWithoutToken() {
+    assertThatThrownBy(() -> new HttpSchemaRegistryClient(REGISTRY_URL, "basic", null))
+        .isInstanceOf(SchemaRegistryException.class)
+        .hasMessageContaining("schema_registry_token is required")
+        .hasMessageContaining("basic");
+  }
+
+  @Test
+  void throwsWhenBasicAuthConfiguredWithBlankToken() {
+    assertThatThrownBy(() -> new HttpSchemaRegistryClient(REGISTRY_URL, "basic", ""))
+        .isInstanceOf(SchemaRegistryException.class)
+        .hasMessageContaining("schema_registry_token is required")
+        .hasMessageContaining("basic");
+  }
+
+  @Test
+  void exceptionMessageNeverContainsTokenValue() {
+    String secretToken = "super-secret-value-12345";
+
+    assertThatThrownBy(
+            () -> new HttpSchemaRegistryClient(REGISTRY_URL, "unknown-type", secretToken))
+        .hasMessageNotContaining(secretToken);
+  }
+
+  @Test
+  void noAuthWhenAuthTypeIsNullEvenWithToken() {
+    // null/blank authType stays "no auth", regardless of token — unchanged behavior.
+    assertThatCode(
+            () -> new HttpSchemaRegistryClient(REGISTRY_URL, (String) null, "irrelevant-token"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void noAuthWhenAuthTypeIsBlankEvenWithToken() {
+    assertThatCode(() -> new HttpSchemaRegistryClient(REGISTRY_URL, "   ", "irrelevant-token"))
+        .doesNotThrowAnyException();
+  }
 }

--- a/formats/src/test/java/com/datagenerator/formats/avro/HttpSchemaRegistryClientTest.java
+++ b/formats/src/test/java/com/datagenerator/formats/avro/HttpSchemaRegistryClientTest.java
@@ -282,11 +282,12 @@ class HttpSchemaRegistryClientTest {
 
   @Test
   void exceptionMessageNeverContainsTokenValue() {
-    String secretToken = "super-secret-value-12345";
+    // Deliberately NOT named like a credential: static analyzers flag `secretToken = "literal"`
+    // as a hardcoded password. This is a leak probe, not a credential.
+    String leakProbe = "leak-probe-12345";
 
-    assertThatThrownBy(
-            () -> new HttpSchemaRegistryClient(REGISTRY_URL, "unknown-type", secretToken))
-        .hasMessageNotContaining(secretToken);
+    assertThatThrownBy(() -> new HttpSchemaRegistryClient(REGISTRY_URL, "unknown-type", leakProbe))
+        .hasMessageNotContaining(leakProbe);
   }
 
   @Test


### PR DESCRIPTION
Unknown `schema_registry_auth` values or a missing token previously produced a null auth header and the request went out **unauthenticated**. Now throws `SchemaRegistryException` with a clear message (never containing the token). No-auth behavior (absent/blank auth type) unchanged.

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhgEN9eTdNgFzDnKKyVxxG