### PR TITLE
fix(security): exclude credentials from AuthConfig toString (T03)

### DIFF
--- a/core/src/main/java/com/datagenerator/core/seed/SeedConfig.java
+++ b/core/src/main/java/com/datagenerator/core/seed/SeedConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import jakarta.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import lombok.Value;
 
 /** Base class for seed configuration. Supports embedded, file, env, and remote seed sources. */
@@ -105,11 +106,11 @@ public abstract sealed class SeedConfig {
     public static class AuthConfig {
       @NotNull String type; // bearer, basic, api_key
 
-      String token; // for bearer
+      @ToString.Exclude String token; // for bearer
       String username; // for basic
-      String password; // for basic
+      @ToString.Exclude String password; // for basic
       String key; // for api_key - header name
-      String value; // for api_key - header value
+      @ToString.Exclude String value; // for api_key - header value
 
       @JsonCreator
       @SuppressWarnings("checkstyle:HiddenField")

--- a/core/src/test/java/com/datagenerator/core/seed/SeedConfigTest.java
+++ b/core/src/test/java/com/datagenerator/core/seed/SeedConfigTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Marco Ferretti
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datagenerator.core.seed;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("SeedConfig")
+class SeedConfigTest {
+
+  @Test
+  @DisplayName("AuthConfig toString should exclude bearer token")
+  void shouldExcludeBearerTokenFromToString() {
+    SeedConfig.RemoteSeed.AuthConfig authConfig =
+        new SeedConfig.RemoteSeed.AuthConfig("bearer", "SECRET_TOKEN", null, null, null, null);
+    String toString = authConfig.toString();
+    assertThat(toString).doesNotContain("SECRET_TOKEN");
+  }
+
+  @Test
+  @DisplayName("AuthConfig toString should exclude basic password")
+  void shouldExcludeBasicPasswordFromToString() {
+    SeedConfig.RemoteSeed.AuthConfig authConfig =
+        new SeedConfig.RemoteSeed.AuthConfig("basic", null, "user", "SECRET_PASSWORD", null, null);
+    String toString = authConfig.toString();
+    assertThat(toString).doesNotContain("SECRET_PASSWORD");
+  }
+
+  @Test
+  @DisplayName("AuthConfig toString should exclude api_key value")
+  void shouldExcludeApiKeyValueFromToString() {
+    SeedConfig.RemoteSeed.AuthConfig authConfig =
+        new SeedConfig.RemoteSeed.AuthConfig(
+            "api_key", null, null, null, "X-API-Key", "SECRET_VALUE");
+    String toString = authConfig.toString();
+    assertThat(toString).doesNotContain("SECRET_VALUE");
+  }
+
+  @Test
+  @DisplayName("AuthConfig toString should include non-sensitive fields")
+  void shouldIncludeNonSensitiveFields() {
+    SeedConfig.RemoteSeed.AuthConfig authConfig =
+        new SeedConfig.RemoteSeed.AuthConfig(
+            "basic", null, "testuser", "SECRET_PASSWORD", null, null);
+    String toString = authConfig.toString();
+    assertThat(toString).contains("basic").contains("testuser");
+  }
+}


### PR DESCRIPTION
Lombok @Value generated a toString() exposing remote-seed token, password, and api-key value (CWE-532, latent). Added @ToString.Exclude to the three sensitive fields + tests proving toString omits them.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhgEN9eTdNgFzDnKKyVxxG