### PR TITLE
fix(security): avoid NPE when Kafka SSL password is absent (T08)

### DIFF
--- a/destinations/src/main/java/com/datagenerator/destinations/kafka/KafkaDestination.java
+++ b/destinations/src/main/java/com/datagenerator/destinations/kafka/KafkaDestination.java
@@ -168,11 +168,15 @@ public class KafkaDestination extends AbstractDestination {
     // SSL properties
     if (config.getSslTruststoreLocation() != null) {
       props.put("ssl.truststore.location", config.getSslTruststoreLocation());
-      props.put("ssl.truststore.password", config.getSslTruststorePassword());
+      if (config.getSslTruststorePassword() != null) {
+        props.put("ssl.truststore.password", config.getSslTruststorePassword());
+      }
     }
     if (config.getSslKeystoreLocation() != null) {
       props.put("ssl.keystore.location", config.getSslKeystoreLocation());
-      props.put("ssl.keystore.password", config.getSslKeystorePassword());
+      if (config.getSslKeystorePassword() != null) {
+        props.put("ssl.keystore.password", config.getSslKeystorePassword());
+      }
     }
 
     return props;

--- a/destinations/src/test/java/com/datagenerator/destinations/kafka/KafkaDestinationTest.java
+++ b/destinations/src/test/java/com/datagenerator/destinations/kafka/KafkaDestinationTest.java
@@ -163,6 +163,40 @@ class KafkaDestinationTest {
   }
 
   @Test
+  void shouldAllowSslTruststoreLocationWithoutPassword() {
+    KafkaDestinationConfig config =
+        KafkaDestinationConfig.builder()
+            .bootstrap(BOOTSTRAP)
+            .topic(TOPIC)
+            .securityProtocol("SSL")
+            .sslTruststoreLocation("/path/to/truststore.pem")
+            .sslTruststorePassword(null)
+            .build();
+
+    Producer<String, byte[]> mockProducer = mock(Producer.class);
+    // Should not throw NPE when building properties with null password
+    KafkaDestination dest = new KafkaDestination(config, new JsonSerializer(), mockProducer);
+    assertThat(dest).isNotNull();
+  }
+
+  @Test
+  void shouldAllowSslKeystoreLocationWithoutPassword() {
+    KafkaDestinationConfig config =
+        KafkaDestinationConfig.builder()
+            .bootstrap(BOOTSTRAP)
+            .topic(TOPIC)
+            .securityProtocol("SSL")
+            .sslKeystoreLocation("/path/to/keystore.pem")
+            .sslKeystorePassword(null)
+            .build();
+
+    Producer<String, byte[]> mockProducer = mock(Producer.class);
+    // Should not throw NPE when building properties with null password
+    KafkaDestination dest = new KafkaDestination(config, new JsonSerializer(), mockProducer);
+    assertThat(dest).isNotNull();
+  }
+
+  @Test
   @SuppressWarnings("unchecked")
   void shouldRetrySyncSendOnTransientFailure() throws Exception {
     Future<RecordMetadata> failedFuture = mock(Future.class);


### PR DESCRIPTION
Properties.put(key, null) throws (Hashtable). Truststore/keystore locations without a password (valid for PEM truststores) crashed with a bare NPE. Password puts now null-guarded independently + tests.

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhgEN9eTdNgFzDnKKyVxxG