### PR TITLE
fix(security): enforce owner-only permissions on encryption key files (T05)

### DIFF
--- a/cli/src/main/java/com/datagenerator/cli/EncryptCommand.java
+++ b/cli/src/main/java/com/datagenerator/cli/EncryptCommand.java
@@ -16,6 +16,8 @@
 
 package com.datagenerator.cli;
 
+import com.datagenerator.core.security.FilePermissionValidator;
+import com.datagenerator.core.security.PathValidator;
 import com.datagenerator.schema.secret.AesGcmCrypto;
 import java.io.BufferedReader;
 import java.io.Console;
@@ -157,8 +159,10 @@ public class EncryptCommand implements Callable<Integer> {
   private String loadKey() {
     if (keyFile != null && !keyFile.isBlank()) {
       try {
-        return Files.readString(Path.of(keyFile)).trim();
-      } catch (IOException e) {
+        Path keyPath = PathValidator.validate(keyFile, null, "encryption key file");
+        new FilePermissionValidator().validateSecretFile(keyPath, "Encryption key file");
+        return Files.readString(keyPath).trim();
+      } catch (IllegalArgumentException | SecurityException | IOException e) {
         spec.commandLine()
             .getErr()
             .println("Cannot read key file '" + keyFile + "': " + e.getMessage());

--- a/cli/src/test/java/com/datagenerator/cli/EncryptCommandTest.java
+++ b/cli/src/test/java/com/datagenerator/cli/EncryptCommandTest.java
@@ -20,11 +20,15 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.datagenerator.schema.secret.AesGcmCrypto;
 import com.datagenerator.schema.secret.EncryptedFileResolver;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
 
@@ -45,9 +49,26 @@ class EncryptCommandTest {
   void exitCode0WhenKeyFileProvided(@TempDir Path tempDir) throws Exception {
     Path keyFile = tempDir.resolve(KEY_FILE_NAME);
     Files.writeString(keyFile, VALID_KEY_HEX);
+    restrictPermissions(keyFile);
 
     int code = cmd().execute(OPT_KEY_FILE, keyFile.toString(), SECRET_NAME);
     assertThat(code).isZero();
+  }
+
+  @Test
+  @DisabledOnOs(OS.WINDOWS)
+  void exitCode1WhenKeyFileIsWorldReadable(@TempDir Path tempDir) throws Exception {
+    Path keyFile = tempDir.resolve(KEY_FILE_NAME);
+    Files.writeString(keyFile, VALID_KEY_HEX);
+    Files.setPosixFilePermissions(keyFile, PosixFilePermissions.fromString("rw-r--r--"));
+
+    StringWriter err = new StringWriter();
+    CommandLine cli = cmd();
+    cli.setErr(new PrintWriter(err));
+    int code = cli.execute(OPT_KEY_FILE, keyFile.toString(), SECRET_NAME);
+
+    assertThat(code).isEqualTo(1);
+    assertThat(err.toString()).contains("insecure permissions").contains("chmod 600");
   }
 
   @Test
@@ -81,6 +102,7 @@ class EncryptCommandTest {
   void keyFileWithTrailingNewlineSucceeds(@TempDir Path tempDir) throws Exception {
     Path keyFile = tempDir.resolve(KEY_FILE_NAME);
     Files.writeString(keyFile, VALID_KEY_HEX + "\n");
+    restrictPermissions(keyFile);
 
     int code = cmd().execute(OPT_KEY_FILE, keyFile.toString(), SECRET_NAME);
     assertThat(code).isZero();
@@ -92,6 +114,7 @@ class EncryptCommandTest {
   void outputStartsWithAes256GcmPrefix(@TempDir Path tempDir) throws Exception {
     Path keyFile = tempDir.resolve(KEY_FILE_NAME);
     Files.writeString(keyFile, VALID_KEY_HEX);
+    restrictPermissions(keyFile);
 
     StringWriter out = new StringWriter();
     CommandLine cli = cmd();
@@ -105,6 +128,7 @@ class EncryptCommandTest {
   void outputCanBeDecryptedBack(@TempDir Path tempDir) throws Exception {
     Path keyFile = tempDir.resolve(KEY_FILE_NAME);
     Files.writeString(keyFile, VALID_KEY_HEX);
+    restrictPermissions(keyFile);
 
     StringWriter out = new StringWriter();
     CommandLine cli = cmd();
@@ -139,6 +163,7 @@ class EncryptCommandTest {
   void twoCiphertextsForSamePlaintextDiffer(@TempDir Path tempDir) throws Exception {
     Path keyFile = tempDir.resolve(KEY_FILE_NAME);
     Files.writeString(keyFile, VALID_KEY_HEX);
+    restrictPermissions(keyFile);
 
     StringWriter out1 = new StringWriter();
     StringWriter out2 = new StringWriter();
@@ -151,5 +176,18 @@ class EncryptCommandTest {
     c2.execute(OPT_KEY_FILE, keyFile.toString(), "same-value");
 
     assertThat(out1.toString().trim()).isNotEqualTo(out2.toString().trim());
+  }
+
+  /**
+   * Restricts the given file to owner-only permissions on POSIX systems so tests that expect a
+   * successful key-file read aren't tripped up by the umask-dependent default permissions of {@link
+   * Files#writeString}. No-op on Windows, where POSIX permissions are unavailable.
+   */
+  private static void restrictPermissions(Path file) throws IOException {
+    try {
+      Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw-------"));
+    } catch (UnsupportedOperationException e) {
+      // Windows: no POSIX permission model, nothing to restrict.
+    }
   }
 }

--- a/core/src/main/java/com/datagenerator/core/security/FilePermissionValidator.java
+++ b/core/src/main/java/com/datagenerator/core/security/FilePermissionValidator.java
@@ -73,26 +73,43 @@ public class FilePermissionValidator {
    * <p>Seed files may contain sensitive values and must be restricted to owner read/write only
    * ({@code chmod 600}).
    *
-   * <p>Opens the file before reading its POSIX attributes to eliminate the TOCTOU race that would
-   * exist if a separate {@code Files.exists()} check preceded the attribute read.
-   *
    * @param seedFile path to the seed file
    * @throws SecurityException if the seed file has insecure permissions
    */
   public void validateSeedFile(Path seedFile) {
+    validateSecretFile(seedFile, "Seed file");
+  }
+
+  /**
+   * Fails fast if the given secret-bearing file is readable by group or others.
+   *
+   * <p>Used for any file that may hold sensitive material (seed files, AES encryption key files,
+   * etc.) which must be restricted to owner read/write only ({@code chmod 600}).
+   *
+   * <p>Opens the file before reading its POSIX attributes to eliminate the TOCTOU race that would
+   * exist if a separate {@code Files.exists()} check preceded the attribute read.
+   *
+   * @param secretFile path to the secret-bearing file
+   * @param description human-readable description of the file, used in the exception message (e.g.
+   *     {@code "Seed file"}, {@code "Encryption key file"})
+   * @throws SecurityException if the file has insecure permissions
+   */
+  public void validateSecretFile(Path secretFile, String description) {
     if (!IS_POSIX) return;
-    try (FileChannel channel = FileChannel.open(seedFile, StandardOpenOption.READ)) {
-      Set<PosixFilePermission> perms = readPermsFromChannel(seedFile);
+    try (FileChannel channel = FileChannel.open(secretFile, StandardOpenOption.READ)) {
+      Set<PosixFilePermission> perms = readPermsFromChannel(secretFile);
       if (!perms.isEmpty() && isWorldReadable(perms)) {
         throw new SecurityException(
-            "Seed file has insecure permissions (readable by group or others). "
+            description
+                + " has insecure permissions (readable by group or others). "
                 + "Restrict to owner-only: chmod 600 "
-                + seedFile);
+                + secretFile);
       }
     } catch (SecurityException e) {
       throw e;
     } catch (IOException e) {
-      log.debug("Could not read permissions for seed file {}: {}", seedFile, e.getMessage());
+      log.debug(
+          "Could not read permissions for {} {}: {}", description, secretFile, e.getMessage());
     }
   }
 

--- a/schema/src/main/java/com/datagenerator/schema/secret/SecretResolverFactory.java
+++ b/schema/src/main/java/com/datagenerator/schema/secret/SecretResolverFactory.java
@@ -16,6 +16,7 @@
 
 package com.datagenerator.schema.secret;
 
+import com.datagenerator.core.security.FilePermissionValidator;
 import com.datagenerator.core.security.PathValidator;
 import com.datagenerator.schema.exception.SecretResolutionException;
 import com.datagenerator.schema.model.SecretsConfig;
@@ -47,8 +48,11 @@ public final class SecretResolverFactory {
     if (config.getKeyFile() != null && !config.getKeyFile().isBlank()) {
       try {
         Path keyPath = PathValidator.validate(config.getKeyFile(), null, "encryption key file");
+        new FilePermissionValidator().validateSecretFile(keyPath, "Encryption key file");
         return Files.readString(keyPath).trim();
       } catch (IllegalArgumentException e) {
+        throw new SecretResolutionException(e.getMessage(), e);
+      } catch (SecurityException e) {
         throw new SecretResolutionException(e.getMessage(), e);
       } catch (IOException e) {
         throw new SecretResolutionException(

--- a/schema/src/test/java/com/datagenerator/schema/secret/SecretResolverFactoryTest.java
+++ b/schema/src/test/java/com/datagenerator/schema/secret/SecretResolverFactoryTest.java
@@ -23,7 +23,10 @@ import com.datagenerator.schema.model.SecretsConfig;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
@@ -136,10 +139,28 @@ class SecretResolverFactoryTest {
     String keyHex = "0".repeat(64);
     Path keyFile = tempDir.resolve("key.hex");
     Files.writeString(keyFile, keyHex);
+    restrictPermissions(keyFile);
 
     SecretsConfig config =
         new SecretsConfig(TYPE_ENCRYPTED, null, null, null, null, null, keyFile.toString(), null);
     assertThat(SecretResolverFactory.create(config)).isInstanceOf(EncryptedFileResolver.class);
+  }
+
+  @Test
+  @DisabledOnOs(OS.WINDOWS)
+  void shouldThrowWhenEncryptedFileKeyFileIsGroupReadable(@TempDir Path tempDir)
+      throws IOException {
+    String keyHex = "0".repeat(64);
+    Path keyFile = tempDir.resolve("key.hex");
+    Files.writeString(keyFile, keyHex);
+    Files.setPosixFilePermissions(keyFile, PosixFilePermissions.fromString("rw-r--r--"));
+
+    SecretsConfig config =
+        new SecretsConfig(TYPE_ENCRYPTED, null, null, null, null, null, keyFile.toString(), null);
+    assertThatThrownBy(() -> SecretResolverFactory.create(config))
+        .isInstanceOf(SecretResolutionException.class)
+        .hasMessageContaining("insecure permissions")
+        .hasMessageContaining("chmod 600");
   }
 
   @Test
@@ -167,6 +188,7 @@ class SecretResolverFactoryTest {
     byte[] key = new byte[32]; // all-zero 32-byte key → hex "00" * 32
     Path keyFile = tempDir.resolve("key.hex");
     Files.writeString(keyFile, "0".repeat(64));
+    restrictPermissions(keyFile);
 
     String plaintext = "super-secret-value";
     String ciphertext = AesGcmCrypto.encrypt(key, plaintext);
@@ -188,5 +210,18 @@ class SecretResolverFactoryTest {
         .isInstanceOf(SecretResolutionException.class)
         .hasMessageContaining("unknown_backend")
         .hasMessageContaining(TYPE_ENCRYPTED);
+  }
+
+  /**
+   * Restricts the given file to owner-only permissions on POSIX systems so tests that expect a
+   * successful key-file read aren't tripped up by the umask-dependent default permissions of {@link
+   * Files#writeString}. No-op on Windows, where POSIX permissions are unavailable.
+   */
+  private static void restrictPermissions(Path file) throws IOException {
+    try {
+      Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw-------"));
+    } catch (UnsupportedOperationException e) {
+      // Windows: no POSIX permission model, nothing to restrict.
+    }
   }
 }


### PR DESCRIPTION
Seed files fail fast when group/other-readable; the AES-256 master key file had no such check, and encrypt --key-file also skipped PathValidator. Added FilePermissionValidator.validateSecretFile (validateSeedFile delegates, behavior unchanged), applied in SecretResolverFactory.loadEncryptionKey and EncryptCommand.loadKey. POSIX-only tests for the rw-r--r-- failure case.

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhgEN9eTdNgFzDnKKyVxxG