### PR TITLE
fix(security): scope --debug TRACE to application loggers only (T10)

### DIFF
--- a/cli/src/main/java/com/datagenerator/cli/ExecuteCommand.java
+++ b/cli/src/main/java/com/datagenerator/cli/ExecuteCommand.java
@@ -270,6 +270,12 @@ public class ExecuteCommand implements Callable<Integer> {
    * <p><b>Performance Impact:</b> Minimal on generation speed, but log I/O may slow overall
    * execution depending on sample rate.
    *
+   * <p>TRACE is scoped to the {@code com.datagenerator} application logger only; third-party
+   * libraries (e.g. HikariCP, Kafka clients, HTTP clients, cloud SDKs) remain at INFO to avoid
+   * leaking connection strings, credentials, or other sensitive material they log at TRACE/DEBUG.
+   * To enable deep third-party debugging, configure the relevant logger explicitly in {@code
+   * logback.xml}.
+   *
    * @see #verbose
    * @see #traceSample
    */
@@ -857,8 +863,10 @@ public class ExecuteCommand implements Callable<Integer> {
     Logger appLogger = (Logger) LoggerFactory.getLogger("com.datagenerator");
 
     if (debug) {
-      // Enable TRACE logging
-      rootLogger.setLevel(Level.TRACE);
+      // Enable TRACE logging for the application logger only; third-party libraries (HikariCP,
+      // Kafka clients, HTTP clients, cloud SDKs) can log sensitive material at TRACE/DEBUG, so
+      // ROOT stays at INFO.
+      rootLogger.setLevel(Level.INFO);
       appLogger.setLevel(Level.TRACE);
 
       // Set trace sample rate for LogUtils
@@ -869,7 +877,7 @@ public class ExecuteCommand implements Callable<Integer> {
       log.debug(
           "Debug mode enabled - log level set to TRACE (sample rate: {}%)", validatedSampleRate);
     } else if (verbose) {
-      rootLogger.setLevel(Level.DEBUG);
+      rootLogger.setLevel(Level.INFO);
       appLogger.setLevel(Level.DEBUG);
       log.debug("Verbose mode enabled - log level set to DEBUG");
     } else {

--- a/cli/src/test/java/com/datagenerator/cli/ExecuteCommandTest.java
+++ b/cli/src/test/java/com/datagenerator/cli/ExecuteCommandTest.java
@@ -681,4 +681,36 @@ class ExecuteCommandTest {
       System.clearProperty("TEST_REGISTRY_TOKEN");
     }
   }
+
+  // ── T10: --debug/--verbose must not elevate third-party loggers ─────────────
+
+  @Test
+  void debugModeScopesTraceToApplicationLoggerOnly() throws Exception {
+    // Third-party libraries (HikariCP, Kafka clients, ...) must not be elevated by --debug —
+    // only com.datagenerator should move to TRACE, ROOT stays at INFO.
+    Logger thirdPartyLogger = (Logger) LoggerFactory.getLogger("com.zaxxer.hikari");
+    thirdPartyLogger.setLevel(Level.INFO);
+
+    Path jobFile = writeJobFile();
+    int code = execute(OPT_JOB, jobFile.toString(), OPT_COUNT, "1", "--debug");
+
+    assertThat(code).isZero();
+    Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+    Logger app = (Logger) LoggerFactory.getLogger("com.datagenerator");
+    assertThat(app.getLevel()).isEqualTo(Level.TRACE);
+    assertThat(root.getLevel()).isEqualTo(Level.INFO);
+    assertThat(thirdPartyLogger.getLevel()).isEqualTo(Level.INFO);
+  }
+
+  @Test
+  void verboseModeScopesDebugToApplicationLoggerOnly() throws Exception {
+    Path jobFile = writeJobFile();
+    int code = execute(OPT_JOB, jobFile.toString(), OPT_COUNT, "1", "--verbose");
+
+    assertThat(code).isZero();
+    Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+    Logger app = (Logger) LoggerFactory.getLogger("com.datagenerator");
+    assertThat(app.getLevel()).isEqualTo(Level.DEBUG);
+    assertThat(root.getLevel()).isEqualTo(Level.INFO);
+  }
 }


### PR DESCRIPTION
TRACE on the ROOT logger let HikariCP, the Kafka client, and cloud SDKs log at full verbosity — libraries can print connection/config details the app's own redaction never sees. --debug/--verbose now elevate only com.datagenerator; ROOT stays INFO. Javadoc notes logback.xml for deep third-party debugging.

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhgEN9eTdNgFzDnKKyVxxG