### PR TITLE
fix(security): validate file destination output paths (T14)

### DIFF
--- a/cli/src/main/java/com/datagenerator/cli/ExecuteCommand.java
+++ b/cli/src/main/java/com/datagenerator/cli/ExecuteCommand.java
@@ -20,6 +20,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.datagenerator.core.engine.GenerationEngine;
 import com.datagenerator.core.security.FilePermissionValidator;
+import com.datagenerator.core.security.PathValidator;
 import com.datagenerator.core.seed.SeedConfig;
 import com.datagenerator.core.seed.SeedResolver;
 import com.datagenerator.core.structure.StructureLoader;
@@ -54,6 +55,7 @@ import com.datagenerator.schema.secret.ConfigSubstitutor;
 import com.datagenerator.schema.secret.SecretResolver;
 import com.datagenerator.schema.secret.SecretResolverFactory;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
@@ -662,9 +664,15 @@ public class ExecuteCommand implements Callable<Integer> {
     boolean compress = conf.has("compress") && conf.get("compress").asBoolean();
     boolean append = conf.has("append") && conf.get("append").asBoolean();
 
+    String targetPathStr = pathStr + "." + serializer.getFormatName(); // Add extension
+    Path targetPath = PathValidator.validateOutput(targetPathStr, "file destination output path");
+    if (!append && Files.exists(targetPath)) {
+      log.warn("Output file {} exists and will be truncated", targetPath);
+    }
+
     FileDestinationConfig config =
         FileDestinationConfig.builder()
-            .filePath(Paths.get(pathStr + "." + serializer.getFormatName())) // Add extension
+            .filePath(targetPath)
             .compress(compress)
             .append(append)
             .build();

--- a/cli/src/test/java/com/datagenerator/cli/ExecuteCommandTest.java
+++ b/cli/src/test/java/com/datagenerator/cli/ExecuteCommandTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -32,6 +34,8 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -379,6 +383,93 @@ class ExecuteCommandTest {
 
     int code = execute(OPT_JOB, jobFile.toString(), OPT_COUNT, "3");
     assertThat(code).isZero();
+  }
+
+  // ── Output path validation (T14) ─────────────────────────────────────────────
+
+  @Test
+  @DisabledOnOs(OS.WINDOWS)
+  @SuppressFBWarnings("VA_FORMAT_STRING_USES_NEWLINE")
+  void symlinkOutputPathIsRejected() throws Exception {
+    Path realFile = outDir.resolve("real.json");
+    Files.writeString(realFile, "sensitive content");
+    Path symlink = outDir.resolve("output.json");
+    Files.createSymbolicLink(symlink, realFile);
+
+    Path jobFile = tempDir.resolve("symlink_job.yaml");
+    Files.writeString(
+        jobFile,
+        """
+        source: simple.yaml
+        type: file
+        structures_path: %s
+        seed:
+          type: embedded
+          value: 42
+        conf:
+          path: %s/output
+        """
+            .formatted(structDir.toAbsolutePath(), outDir.toAbsolutePath()));
+
+    int code = execute(OPT_JOB, jobFile.toString(), OPT_COUNT, "1");
+
+    assertThat(code).isNotZero();
+    assertThat(Files.readString(realFile)).isEqualTo("sensitive content");
+  }
+
+  @Test
+  @SuppressFBWarnings("VA_FORMAT_STRING_USES_NEWLINE")
+  void directoryAsOutputPathIsRejected() throws Exception {
+    Path asDir = outDir.resolve("output.json");
+    Files.createDirectories(asDir);
+
+    Path jobFile = tempDir.resolve("dir_target_job.yaml");
+    Files.writeString(
+        jobFile,
+        """
+        source: simple.yaml
+        type: file
+        structures_path: %s
+        seed:
+          type: embedded
+          value: 42
+        conf:
+          path: %s/output
+        """
+            .formatted(structDir.toAbsolutePath(), outDir.toAbsolutePath()));
+
+    int code = execute(OPT_JOB, jobFile.toString(), OPT_COUNT, "1");
+    assertThat(code).isNotZero();
+  }
+
+  @Test
+  @SuppressFBWarnings("VA_FORMAT_STRING_USES_NEWLINE")
+  void existingFileWithAppendFalseLogsWarnAndStillWrites() throws Exception {
+    Path existing = outDir.resolve(OUTPUT_JSON);
+    Files.writeString(existing, "stale data\n");
+
+    Logger appLogger = (Logger) LoggerFactory.getLogger("com.datagenerator");
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    appLogger.addAppender(appender);
+
+    Path jobFile = writeJobFile();
+    int code;
+    try {
+      code = execute(OPT_JOB, jobFile.toString(), OPT_COUNT, "2");
+    } finally {
+      appLogger.detachAppender(appender);
+      appender.stop();
+    }
+
+    assertThat(code).isZero();
+    assertThat(appender.list)
+        .anyMatch(
+            event ->
+                event.getLevel() == Level.WARN
+                    && event.getFormattedMessage().contains("will be truncated"));
+    List<String> lines = Files.readAllLines(existing);
+    assertThat(lines).hasSize(2); // truncated and rewritten, not appended to stale data
   }
 
   // ── Seed resolution edge cases ───────────────────────────────────────────────

--- a/cli/src/test/java/com/datagenerator/cli/ExecuteCommandTest.java
+++ b/cli/src/test/java/com/datagenerator/cli/ExecuteCommandTest.java
@@ -443,7 +443,6 @@ class ExecuteCommandTest {
   }
 
   @Test
-  @SuppressFBWarnings("VA_FORMAT_STRING_USES_NEWLINE")
   void existingFileWithAppendFalseLogsWarnAndStillWrites() throws Exception {
     Path existing = outDir.resolve(OUTPUT_JSON);
     Files.writeString(existing, "stale data\n");

--- a/core/src/main/java/com/datagenerator/core/security/PathValidator.java
+++ b/core/src/main/java/com/datagenerator/core/security/PathValidator.java
@@ -89,4 +89,45 @@ public final class PathValidator {
 
     return resolved;
   }
+
+  /**
+   * Validates a user-supplied output path before it is opened for writing.
+   *
+   * <p>Unlike {@link #validate}, the target need not already exist — output destinations routinely
+   * create a new file. This method is guardrail-level only (no base-directory confinement, callers
+   * point generated data wherever they choose); it exists to stop the two concrete write-time
+   * hazards:
+   *
+   * <ol>
+   *   <li>Writing through a symlink, which can redirect generated data onto an arbitrary file the
+   *       process can write (e.g. {@code ~/.bashrc}, another job's seed file).
+   *   <li>Writing to a path that resolves to an existing non-regular file (device node, symlink to
+   *       a directory, etc.).
+   * </ol>
+   *
+   * @param rawPath the path string from configuration
+   * @param context human-readable context for the exception message (e.g. "file destination output
+   *     path")
+   * @return the normalized {@link Path}, ready to be opened for writing
+   * @throws IllegalArgumentException if the path is null/blank, resolves through a symlink, or
+   *     resolves to an existing non-regular file
+   */
+  public static Path validateOutput(String rawPath, String context) {
+    if (rawPath == null || rawPath.isBlank()) {
+      throw new IllegalArgumentException(context + " must not be null or blank");
+    }
+
+    Path normalized = Path.of(rawPath).normalize();
+
+    if (Files.isSymbolicLink(normalized)) {
+      throw new IllegalArgumentException(
+          context + " refuses to write through a symlink: '" + normalized + "'");
+    }
+
+    if (Files.exists(normalized) && !Files.isRegularFile(normalized)) {
+      throw new IllegalArgumentException(context + " is not a regular file: '" + normalized + "'");
+    }
+
+    return normalized;
+  }
 }

--- a/core/src/test/java/com/datagenerator/core/security/PathValidatorTest.java
+++ b/core/src/test/java/com/datagenerator/core/security/PathValidatorTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 Marco Ferretti
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datagenerator.core.security;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+class PathValidatorTest {
+
+  private static final String CONTEXT = "file destination output path";
+
+  @TempDir Path tempDir;
+
+  // ── validate (read-oriented, existing behavior) ──────────────────────────
+
+  @Test
+  void shouldRejectBlankPath() {
+    assertThatThrownBy(() -> PathValidator.validate("", null, CONTEXT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must not be null or blank");
+  }
+
+  // ── validateOutput ─────────────────────────────────────────────────────
+
+  @Test
+  void shouldRejectBlankOutputPath() {
+    assertThatThrownBy(() -> PathValidator.validateOutput("", CONTEXT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must not be null or blank");
+  }
+
+  @Test
+  void shouldRejectNullOutputPath() {
+    assertThatThrownBy(() -> PathValidator.validateOutput(null, CONTEXT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must not be null or blank");
+  }
+
+  @Test
+  void shouldAllowOutputPathThatDoesNotExistYet() {
+    Path target = tempDir.resolve("new-output.json");
+    assertThatNoException()
+        .isThrownBy(
+            () -> {
+              Path resolved = PathValidator.validateOutput(target.toString(), CONTEXT);
+              assertThat(resolved).isEqualTo(target.normalize());
+            });
+  }
+
+  @Test
+  void shouldAllowOutputPathThatIsAnExistingRegularFile() throws IOException {
+    Path target = tempDir.resolve("existing.json");
+    Files.writeString(target, "old content");
+
+    assertThatNoException()
+        .isThrownBy(() -> PathValidator.validateOutput(target.toString(), CONTEXT));
+  }
+
+  @Test
+  void shouldRejectDirectoryAsOutputTarget() throws IOException {
+    Path dir = tempDir.resolve("a-directory");
+    Files.createDirectory(dir);
+
+    assertThatThrownBy(() -> PathValidator.validateOutput(dir.toString(), CONTEXT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not a regular file");
+  }
+
+  @Test
+  @DisabledOnOs(OS.WINDOWS)
+  void shouldRejectSymlinkTarget() throws IOException {
+    Path realFile = tempDir.resolve("real.json");
+    Files.writeString(realFile, "sensitive content");
+    Path symlink = tempDir.resolve("link.json");
+    Files.createSymbolicLink(symlink, realFile);
+
+    assertThatThrownBy(() -> PathValidator.validateOutput(symlink.toString(), CONTEXT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("symlink");
+  }
+
+  @Test
+  @DisabledOnOs(OS.WINDOWS)
+  void shouldRejectSymlinkToDirectoryTarget() throws IOException {
+    Path realDir = tempDir.resolve("real-dir");
+    Files.createDirectory(realDir);
+    Path symlink = tempDir.resolve("dir-link");
+    Files.createSymbolicLink(symlink, realDir);
+
+    assertThatThrownBy(() -> PathValidator.validateOutput(symlink.toString(), CONTEXT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("symlink");
+  }
+}


### PR DESCRIPTION
Output paths came straight from job YAML: parents auto-created, non-append mode truncates any existing file, symlinks followed silently. New PathValidator.validateOutput refuses symlink targets and non-regular files; createFileDestination WARN-logs before truncating an existing file. Guardrails only — no base-dir confinement (jobs legitimately write wherever the operator points them).

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhgEN9eTdNgFzDnKKyVxxG