### PR TITLE
fix(security): honest advisory-check docs in FilePermissionValidator (T11)

### DIFF
--- a/core/src/main/java/com/datagenerator/core/security/FilePermissionValidator.java
+++ b/core/src/main/java/com/datagenerator/core/security/FilePermissionValidator.java
@@ -17,10 +17,8 @@
 package com.datagenerator.core.security;
 
 import java.io.IOException;
-import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Collections;
@@ -36,6 +34,11 @@ import lombok.extern.slf4j.Slf4j;
  * values and should be owner-only: {@code chmod 600}).
  *
  * <p>On Windows, POSIX permissions are not available — all checks are silently skipped.
+ *
+ * <p><b>Note:</b> this is a best-effort advisory check, not a TOCTOU-safe gate. The permission read
+ * and any later open/read of the file are separate operations on the path, so a symlink swap or
+ * permission change between the two is not prevented. The goal is to flag obviously misconfigured
+ * files, not to guarantee the file is untampered with at the moment it is actually consumed.
  */
 @Slf4j
 public class FilePermissionValidator {
@@ -46,15 +49,15 @@ public class FilePermissionValidator {
   /**
    * Warns if the given configuration file is readable by group or others.
    *
-   * <p>Opens the file before reading its POSIX attributes to eliminate the TOCTOU race that would
-   * exist if a separate {@code Files.exists()} check preceded the attribute read.
+   * <p>This is a best-effort advisory check performed on the path; see the class-level note for why
+   * it does not eliminate TOCTOU races.
    *
    * @param configFile path to the configuration file
    */
   public void validateConfigFile(Path configFile) {
     if (!IS_POSIX) return;
-    try (FileChannel channel = FileChannel.open(configFile, StandardOpenOption.READ)) {
-      Set<PosixFilePermission> perms = readPermsFromChannel(configFile);
+    try {
+      Set<PosixFilePermission> perms = readPerms(configFile);
       if (!perms.isEmpty() && isWorldReadable(perms)) {
         log.warn(
             "Configuration file {} has permissive permissions (readable by group or others). "
@@ -86,8 +89,8 @@ public class FilePermissionValidator {
    * <p>Used for any file that may hold sensitive material (seed files, AES encryption key files,
    * etc.) which must be restricted to owner read/write only ({@code chmod 600}).
    *
-   * <p>Opens the file before reading its POSIX attributes to eliminate the TOCTOU race that would
-   * exist if a separate {@code Files.exists()} check preceded the attribute read.
+   * <p>This is a best-effort advisory check performed on the path; see the class-level note for why
+   * it does not eliminate TOCTOU races.
    *
    * @param secretFile path to the secret-bearing file
    * @param description human-readable description of the file, used in the exception message (e.g.
@@ -96,8 +99,8 @@ public class FilePermissionValidator {
    */
   public void validateSecretFile(Path secretFile, String description) {
     if (!IS_POSIX) return;
-    try (FileChannel channel = FileChannel.open(secretFile, StandardOpenOption.READ)) {
-      Set<PosixFilePermission> perms = readPermsFromChannel(secretFile);
+    try {
+      Set<PosixFilePermission> perms = readPerms(secretFile);
       if (!perms.isEmpty() && isWorldReadable(perms)) {
         throw new SecurityException(
             description
@@ -114,22 +117,20 @@ public class FilePermissionValidator {
   }
 
   /**
-   * Reads POSIX permissions atomically via an already-open FileChannel.
+   * Reads POSIX permissions for the given path.
    *
-   * <p>The channel is opened first so the JVM holds a file-descriptor reference to the inode.
-   * Reading attributes via that same channel's path avoids a classic TOCTOU window (check-then-act
-   * on the path string). Returns an empty set when POSIX attributes are unavailable.
+   * <p>This is a plain, single-shot attribute lookup on the path — not synchronized with any later
+   * open or read of the same file. Returns an empty set when POSIX attributes are unavailable (e.g.
+   * on a filesystem without POSIX support).
+   *
+   * @throws IOException if the attributes cannot be read (e.g. the file does not exist)
    */
-  private static Set<PosixFilePermission> readPermsFromChannel(Path path) {
+  private static Set<PosixFilePermission> readPerms(Path path) throws IOException {
     PosixFileAttributeView view = Files.getFileAttributeView(path, PosixFileAttributeView.class);
     if (view == null) {
       return Collections.emptySet();
     }
-    try {
-      return view.readAttributes().permissions();
-    } catch (IOException e) {
-      return Collections.emptySet();
-    }
+    return view.readAttributes().permissions();
   }
 
   private static boolean isWorldReadable(Set<PosixFilePermission> perms) {


### PR DESCRIPTION
The javadoc claimed TOCTOU elimination via an open FileChannel, but attributes were re-read by path — the channel added nothing (and portable NIO offers no channel-based PosixFileAttributeView). Dropped the channel dance, documented the check honestly as best-effort advisory. Behavior unchanged; existing tests green unmodified.

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhgEN9eTdNgFzDnKKyVxxG