### PR TITLE
fix(security): truncate HTTP response bodies in exception messages (T09)

### DIFF
--- a/core/src/main/java/com/datagenerator/core/seed/SeedResolver.java
+++ b/core/src/main/java/com/datagenerator/core/seed/SeedResolver.java
@@ -42,6 +42,12 @@ public class SeedResolver {
   /** Hard timeout for a single remote-seed request (Core-2: prevents an indefinite read hang). */
   private static final Duration REMOTE_REQUEST_TIMEOUT = Duration.ofSeconds(30);
 
+  /**
+   * Cap on response-body characters embedded in exception messages (CWE-209/532: avoid unbounded
+   * log growth / leaking excessive server-side detail).
+   */
+  private static final int MAX_RESPONSE_BODY_LOG_CHARS = 200;
+
   // LazyHolder defers HttpClient construction until resolveRemote() is first called
   private static final class HttpClientHolder {
     static final HttpClient INSTANCE =
@@ -180,7 +186,10 @@ public class SeedResolver {
 
       if (response.statusCode() != 200) {
         throw new SeedResolutionException(
-            "Remote seed API returned status " + response.statusCode() + ": " + response.body());
+            "Remote seed API returned status "
+                + response.statusCode()
+                + ": "
+                + LogUtils.truncate(response.body(), MAX_RESPONSE_BODY_LOG_CHARS));
       }
 
       long seed = Long.parseLong(response.body().trim());

--- a/core/src/main/java/com/datagenerator/core/util/LogUtils.java
+++ b/core/src/main/java/com/datagenerator/core/util/LogUtils.java
@@ -127,4 +127,24 @@ public final class LogUtils {
     // Statistical sampling: generate random number 0-99, check if < sampleRate
     return ThreadLocalRandom.current().nextInt(100) < TRACE_SAMPLE_RATE;
   }
+
+  /**
+   * Truncates a string to at most {@code max} characters, appending an ellipsis marker with the
+   * original length when truncation occurs.
+   *
+   * <p>Intended for embedding untrusted or potentially large external content (e.g. HTTP response
+   * bodies) into exception messages / log lines without risking unbounded log growth or leaking
+   * excessive server-side detail (CWE-209/532).
+   *
+   * @param s the string to truncate; {@code null} is treated as empty
+   * @param max the maximum number of characters to retain from {@code s}
+   * @return {@code s} unchanged if its length is {@code <= max}, otherwise the first {@code max}
+   *     characters followed by a truncation marker noting the total original length
+   */
+  public static String truncate(String s, int max) {
+    if (s == null) {
+      return "";
+    }
+    return s.length() <= max ? s : s.substring(0, max) + "… (" + s.length() + " chars total)";
+  }
 }

--- a/core/src/test/java/com/datagenerator/core/seed/SeedResolverTest.java
+++ b/core/src/test/java/com/datagenerator/core/seed/SeedResolverTest.java
@@ -225,6 +225,25 @@ class SeedResolverTest {
   }
 
   @Test
+  void shouldTruncateLargeErrorBodyInExceptionMessage() throws Exception {
+    String hugeBody = "x".repeat(10_000);
+    HttpClient mockClient = mock(HttpClient.class);
+    HttpResponse<String> mockResponse = mock(HttpResponse.class);
+    when(mockResponse.statusCode()).thenReturn(500);
+    when(mockResponse.body()).thenReturn(hugeBody);
+    when(mockClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(mockResponse);
+
+    SeedResolver customResolver = new SeedResolver(mockClient);
+    SeedConfig.RemoteSeed config = new SeedConfig.RemoteSeed(TYPE_REMOTE, REMOTE_URL, null);
+
+    assertThatThrownBy(() -> customResolver.resolve(config))
+        .isInstanceOf(SeedResolutionException.class)
+        .hasMessageContaining("… (10000 chars total)")
+        .satisfies(e -> assertThat(e.getMessage()).hasSizeLessThanOrEqualTo(300));
+  }
+
+  @Test
   void shouldFailWhenRemoteThrowsIOException() throws Exception {
     HttpClient mockClient = mock(HttpClient.class);
     when(mockClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))

--- a/core/src/test/java/com/datagenerator/core/util/LogUtilsTest.java
+++ b/core/src/test/java/com/datagenerator/core/util/LogUtilsTest.java
@@ -159,4 +159,33 @@ class LogUtilsTest {
           .isLessThan(1000);
     }
   }
+
+  @Test
+  void truncateShouldReturnEmptyStringForNullInput() {
+    assertThat(LogUtils.truncate(null, 200)).isEmpty();
+  }
+
+  @Test
+  void truncateShouldReturnShortBodyUnchanged() {
+    String body = "short response body";
+    assertThat(LogUtils.truncate(body, 200)).isEqualTo(body);
+  }
+
+  @Test
+  void truncateShouldReturnStringUnchangedWhenExactlyAtLimit() {
+    String body = "x".repeat(200);
+    assertThat(LogUtils.truncate(body, 200)).isEqualTo(body);
+  }
+
+  @Test
+  void truncateShouldCapLargeBodyAndAppendMarker() {
+    String body = "x".repeat(10_000);
+
+    String result = LogUtils.truncate(body, 200);
+
+    assertThat(result)
+        .hasSizeLessThanOrEqualTo(300)
+        .startsWith("x".repeat(200))
+        .endsWith("… (10000 chars total)");
+  }
 }

--- a/formats/src/main/java/com/datagenerator/formats/avro/HttpSchemaRegistryClient.java
+++ b/formats/src/main/java/com/datagenerator/formats/avro/HttpSchemaRegistryClient.java
@@ -17,6 +17,7 @@
 package com.datagenerator.formats.avro;
 
 import com.datagenerator.core.security.UrlValidator;
+import com.datagenerator.core.util.LogUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -54,6 +55,12 @@ public final class HttpSchemaRegistryClient implements SchemaRegistryClient {
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final String CONTENT_TYPE = "application/vnd.schemaregistry.v1+json";
   private static final HttpClient SHARED_HTTP_CLIENT = HttpClient.newHttpClient();
+
+  /**
+   * Cap on response-body characters embedded in exception messages (CWE-209/532: avoid unbounded
+   * log growth / leaking excessive server-side detail).
+   */
+  private static final int MAX_RESPONSE_BODY_LOG_CHARS = 200;
 
   private final String baseUrl;
   private final String authHeader;
@@ -128,7 +135,7 @@ public final class HttpSchemaRegistryClient implements SchemaRegistryClient {
               + " for subject '"
               + subject
               + "': "
-              + response.body());
+              + LogUtils.truncate(response.body(), MAX_RESPONSE_BODY_LOG_CHARS));
     }
 
     int id = parseSchemaId(response.body(), subject);

--- a/formats/src/test/java/com/datagenerator/formats/avro/HttpSchemaRegistryClientTest.java
+++ b/formats/src/test/java/com/datagenerator/formats/avro/HttpSchemaRegistryClientTest.java
@@ -152,6 +152,16 @@ class HttpSchemaRegistryClientTest {
   }
 
   @Test
+  void truncatesLargeResponseBodyOnNon200Response() throws Exception {
+    stubResponse(500, "x".repeat(10_000));
+
+    assertThatThrownBy(() -> client.registerSchema("s", "{}"))
+        .isInstanceOf(SchemaRegistryException.class)
+        .hasMessageContaining("… (10000 chars total)")
+        .satisfies(e -> assertThat(e.getMessage()).hasSizeLessThanOrEqualTo(300));
+  }
+
+  @Test
   void throwsOnMalformedJsonResponse() throws Exception {
     stubResponse(200, "not-json");
 


### PR DESCRIPTION
Remote-seed and Schema Registry error paths embedded entire server response bodies in exception messages (CWE-209; bodies can be huge HTML error pages or contain server-side detail). Bodies now truncated at 200 chars via LogUtils.truncate with an explicit marker.

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhgEN9eTdNgFzDnKKyVxxG