### PR TITLE
fix(security): add https-only URL validation and warn on credentials over http (T07)

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,4 +7,7 @@ dependencies {
 
     // Fake data generation
     implementation(libs.datafaker)
+
+    // Logback test appender for asserting on WARN log output
+    testImplementation(libs.logback.classic)
 }

--- a/core/src/main/java/com/datagenerator/core/security/UrlValidator.java
+++ b/core/src/main/java/com/datagenerator/core/security/UrlValidator.java
@@ -22,9 +22,10 @@ import java.net.URISyntaxException;
 /**
  * Validates outbound URLs to prevent Server-Side Request Forgery (SSRF).
  *
- * <p>Only {@code https} and {@code http} schemes are allowed. Plain {@code http} is permitted
- * because internal deployments (Vault, Schema Registry, seed APIs) frequently run without TLS on
- * secured networks. Callers that require TLS enforcement should pass {@code httpsOnly = true}.
+ * <p>Only {@code https} and {@code http} schemes are allowed. Plain {@code http} is permitted by
+ * default because internal deployments (Vault, Schema Registry, seed APIs) frequently run without
+ * TLS on secured networks. Callers that require TLS enforcement should call {@link
+ * #validate(String, String, boolean)} with {@code httpsOnly = true}.
  *
  * <p>The validator never resolves DNS — it operates purely on the string representation of the URI.
  */
@@ -33,7 +34,8 @@ public final class UrlValidator {
   private UrlValidator() {}
 
   /**
-   * Validates that {@code url} is a well-formed HTTP/HTTPS URL.
+   * Validates that {@code url} is a well-formed HTTP/HTTPS URL. Equivalent to {@link
+   * #validate(String, String, boolean)} with {@code httpsOnly = false}.
    *
    * @param url the URL to validate
    * @param context human-readable context for the exception message (e.g. "remote seed URL")
@@ -41,6 +43,21 @@ public final class UrlValidator {
    *     scheme
    */
   public static void validate(String url, String context) {
+    validate(url, context, false);
+  }
+
+  /**
+   * Validates that {@code url} is a well-formed HTTP/HTTPS URL, optionally rejecting plain {@code
+   * http}.
+   *
+   * @param url the URL to validate
+   * @param context human-readable context for the exception message (e.g. "remote seed URL")
+   * @param httpsOnly if {@code true}, a {@code http} scheme is rejected — only {@code https} is
+   *     accepted
+   * @throws IllegalArgumentException if the URL is null, blank, malformed, uses a non-HTTP scheme,
+   *     or (when {@code httpsOnly}) uses plain {@code http}
+   */
+  public static void validate(String url, String context, boolean httpsOnly) {
     if (url == null || url.isBlank()) {
       throw new IllegalArgumentException(context + " must not be null or blank");
     }
@@ -60,8 +77,34 @@ public final class UrlValidator {
               + url
               + "'");
     }
+    if (httpsOnly && scheme.equalsIgnoreCase("http")) {
+      throw new IllegalArgumentException(
+          context + " requires https; got plain http: '" + url + "'");
+    }
     if (uri.getHost() == null || uri.getHost().isBlank()) {
       throw new IllegalArgumentException(context + " is missing a host: '" + url + "'");
+    }
+  }
+
+  /**
+   * Returns whether {@code url} uses the {@code https} scheme.
+   *
+   * <p>Intended for callers that already validated the URL via {@link #validate(String, String)}
+   * and now need to branch on scheme (e.g. to warn when sending credentials over plain {@code
+   * http}). Malformed URLs are reported as not-https rather than throwing.
+   *
+   * @param url the URL to inspect
+   * @return {@code true} if {@code url} has an {@code https} scheme (case-insensitive), {@code
+   *     false} otherwise (including {@code null}, blank, or malformed input)
+   */
+  public static boolean isHttps(String url) {
+    if (url == null || url.isBlank()) {
+      return false;
+    }
+    try {
+      return "https".equalsIgnoreCase(new URI(url).getScheme());
+    } catch (URISyntaxException e) {
+      return false;
     }
   }
 }

--- a/core/src/main/java/com/datagenerator/core/seed/SeedResolver.java
+++ b/core/src/main/java/com/datagenerator/core/seed/SeedResolver.java
@@ -174,6 +174,12 @@ public class SeedResolver {
   private long resolveRemote(SeedConfig.RemoteSeed remoteSeed) {
     String url = remoteSeed.getUrl();
     UrlValidator.validate(url, "remote seed URL");
+    if (remoteSeed.getAuth() != null && !UrlValidator.isHttps(url)) {
+      log.warn(
+          "Sending credentials over plain http to {} — use https to protect credentials in "
+              + "transit",
+          url);
+    }
     HttpClient client = injectedHttpClient != null ? injectedHttpClient : HttpClientHolder.INSTANCE;
     HttpRequest.Builder requestBuilder =
         HttpRequest.newBuilder().uri(URI.create(url)).timeout(REMOTE_REQUEST_TIMEOUT).GET();

--- a/core/src/test/java/com/datagenerator/core/security/UrlValidatorTest.java
+++ b/core/src/test/java/com/datagenerator/core/security/UrlValidatorTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026 Marco Ferretti
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datagenerator.core.security;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class UrlValidatorTest {
+
+  private static final String CONTEXT = "test URL";
+
+  // ── validate(url, context) — unchanged 2-arg behavior ────────────────────
+
+  @Test
+  void shouldAcceptHttpsUrlViaTwoArgOverload() {
+    assertThatCode(() -> UrlValidator.validate("https://example.com/path", CONTEXT))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldAcceptHttpUrlViaTwoArgOverload() {
+    assertThatCode(() -> UrlValidator.validate("http://example.com/path", CONTEXT))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectBlankUrlViaTwoArgOverload() {
+    assertThatThrownBy(() -> UrlValidator.validate("  ", CONTEXT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must not be null or blank");
+  }
+
+  @Test
+  void shouldRejectNonHttpSchemeViaTwoArgOverload() {
+    assertThatThrownBy(() -> UrlValidator.validate("ftp://example.com/path", CONTEXT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must use http or https scheme");
+  }
+
+  @Test
+  void shouldRejectMissingHostViaTwoArgOverload() {
+    assertThatThrownBy(() -> UrlValidator.validate("https:///path", CONTEXT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("missing a host");
+  }
+
+  // ── validate(url, context, httpsOnly) ─────────────────────────────────────
+
+  @Test
+  void shouldAcceptHttpsUrlWhenHttpsOnlyIsTrue() {
+    assertThatCode(() -> UrlValidator.validate("https://example.com/path", CONTEXT, true))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectHttpUrlWhenHttpsOnlyIsTrue() {
+    assertThatThrownBy(() -> UrlValidator.validate("http://example.com/path", CONTEXT, true))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(CONTEXT)
+        .hasMessageContaining("requires https");
+  }
+
+  @Test
+  void shouldAcceptHttpUrlWhenHttpsOnlyIsFalse() {
+    assertThatCode(() -> UrlValidator.validate("http://example.com/path", CONTEXT, false))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldStillRejectNonHttpSchemeWhenHttpsOnlyIsTrue() {
+    assertThatThrownBy(() -> UrlValidator.validate("ftp://example.com/path", CONTEXT, true))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must use http or https scheme");
+  }
+
+  @Test
+  void shouldRejectBlankUrlWhenHttpsOnlyIsTrue() {
+    assertThatThrownBy(() -> UrlValidator.validate(null, CONTEXT, true))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must not be null or blank");
+  }
+
+  // ── isHttps ────────────────────────────────────────────────────────────────
+
+  @Test
+  void isHttpsShouldReturnTrueForHttpsUrl() {
+    assertThat(UrlValidator.isHttps("https://example.com/path")).isTrue();
+  }
+
+  @Test
+  void isHttpsShouldReturnFalseForHttpUrl() {
+    assertThat(UrlValidator.isHttps("http://example.com/path")).isFalse();
+  }
+
+  @Test
+  void isHttpsShouldBeCaseInsensitive() {
+    assertThat(UrlValidator.isHttps("HTTPS://example.com/path")).isTrue();
+  }
+
+  @Test
+  void isHttpsShouldReturnFalseForNull() {
+    assertThat(UrlValidator.isHttps(null)).isFalse();
+  }
+
+  @Test
+  void isHttpsShouldReturnFalseForBlank() {
+    assertThat(UrlValidator.isHttps("  ")).isFalse();
+  }
+
+  @Test
+  void isHttpsShouldReturnFalseForMalformedUrl() {
+    assertThat(UrlValidator.isHttps("not a url")).isFalse();
+  }
+}

--- a/core/src/test/java/com/datagenerator/core/seed/SeedResolverTest.java
+++ b/core/src/test/java/com/datagenerator/core/seed/SeedResolverTest.java
@@ -20,6 +20,10 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.datagenerator.core.exception.SeedResolutionException;
 import java.io.IOException;
 import java.net.http.HttpClient;
@@ -34,10 +38,12 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.LoggerFactory;
 
 class SeedResolverTest {
   private static final String TYPE_REMOTE = "remote";
   private static final String REMOTE_URL = "https://api.example.com/seed";
+  private static final String HTTP_REMOTE_URL = "http://api.example.com/seed";
   private static final String API_KEY_HEADER = "X-API-Key";
   private static final String ENV_SEED_KEY = "SEEDSTREAM_TEST_ENV_SEED_42";
 
@@ -328,5 +334,94 @@ class SeedResolverTest {
     assertThatThrownBy(() -> resolver.resolve(config))
         .isInstanceOf(SeedResolutionException.class)
         .hasMessageContaining("empty");
+  }
+
+  // ── TLS warnings (T07 / CWE-319) ──────────────────────────────────────────
+
+  private ListAppender<ILoggingEvent> attachAppender() {
+    Logger logger = (Logger) LoggerFactory.getLogger(SeedResolver.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    return appender;
+  }
+
+  private void detachAppender(ListAppender<ILoggingEvent> appender) {
+    Logger logger = (Logger) LoggerFactory.getLogger(SeedResolver.class);
+    logger.detachAppender(appender);
+    appender.stop();
+  }
+
+  @Test
+  void shouldWarnWhenSendingCredentialsOverPlainHttp() throws Exception {
+    ListAppender<ILoggingEvent> appender = attachAppender();
+    try {
+      HttpClient mockClient = mock(HttpClient.class);
+      HttpResponse<String> mockResponse = mock(HttpResponse.class);
+      when(mockResponse.statusCode()).thenReturn(200);
+      when(mockResponse.body()).thenReturn("123");
+      when(mockClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+          .thenReturn(mockResponse);
+
+      SeedConfig.RemoteSeed.AuthConfig auth =
+          new SeedConfig.RemoteSeed.AuthConfig(
+              "bearer", "super-secret-token", null, null, null, null);
+      SeedConfig.RemoteSeed config = new SeedConfig.RemoteSeed(TYPE_REMOTE, HTTP_REMOTE_URL, auth);
+      new SeedResolver(mockClient).resolve(config);
+
+      assertThat(appender.list)
+          .anySatisfy(
+              event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                assertThat(event.getFormattedMessage())
+                    .contains("plain http")
+                    .doesNotContain("super-secret-token");
+              });
+    } finally {
+      detachAppender(appender);
+    }
+  }
+
+  @Test
+  void shouldNotWarnWhenRemoteSeedHasNoAuth() throws Exception {
+    ListAppender<ILoggingEvent> appender = attachAppender();
+    try {
+      HttpClient mockClient = mock(HttpClient.class);
+      HttpResponse<String> mockResponse = mock(HttpResponse.class);
+      when(mockResponse.statusCode()).thenReturn(200);
+      when(mockResponse.body()).thenReturn("123");
+      when(mockClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+          .thenReturn(mockResponse);
+
+      SeedConfig.RemoteSeed config = new SeedConfig.RemoteSeed(TYPE_REMOTE, HTTP_REMOTE_URL, null);
+      new SeedResolver(mockClient).resolve(config);
+
+      assertThat(appender.list).noneMatch(event -> event.getLevel() == Level.WARN);
+    } finally {
+      detachAppender(appender);
+    }
+  }
+
+  @Test
+  void shouldNotWarnWhenRemoteSeedWithAuthUsesHttps() throws Exception {
+    ListAppender<ILoggingEvent> appender = attachAppender();
+    try {
+      HttpClient mockClient = mock(HttpClient.class);
+      HttpResponse<String> mockResponse = mock(HttpResponse.class);
+      when(mockResponse.statusCode()).thenReturn(200);
+      when(mockResponse.body()).thenReturn("123");
+      when(mockClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+          .thenReturn(mockResponse);
+
+      SeedConfig.RemoteSeed.AuthConfig auth =
+          new SeedConfig.RemoteSeed.AuthConfig(
+              "bearer", "super-secret-token", null, null, null, null);
+      SeedConfig.RemoteSeed config = new SeedConfig.RemoteSeed(TYPE_REMOTE, REMOTE_URL, auth);
+      new SeedResolver(mockClient).resolve(config);
+
+      assertThat(appender.list).noneMatch(event -> event.getLevel() == Level.WARN);
+    } finally {
+      detachAppender(appender);
+    }
   }
 }

--- a/formats/build.gradle.kts
+++ b/formats/build.gradle.kts
@@ -12,4 +12,7 @@ dependencies {
 
     // Avro
     implementation(libs.avro)
+
+    // Logback test appender for asserting on WARN log output
+    testImplementation(libs.logback.classic)
 }

--- a/formats/src/main/java/com/datagenerator/formats/avro/HttpSchemaRegistryClient.java
+++ b/formats/src/main/java/com/datagenerator/formats/avro/HttpSchemaRegistryClient.java
@@ -74,6 +74,12 @@ public final class HttpSchemaRegistryClient implements SchemaRegistryClient {
     UrlValidator.validate(url, "Schema Registry URL");
     this.baseUrl = normalizeUrl(url);
     this.authHeader = buildAuthHeader(authType, token);
+    if (this.authHeader != null && !UrlValidator.isHttps(url)) {
+      log.warn(
+          "Sending Schema Registry credentials over plain http to {} — use https to protect "
+              + "credentials in transit",
+          url);
+    }
     this.httpClient = SHARED_HTTP_CLIENT;
   }
 

--- a/formats/src/test/java/com/datagenerator/formats/avro/HttpSchemaRegistryClientTest.java
+++ b/formats/src/test/java/com/datagenerator/formats/avro/HttpSchemaRegistryClientTest.java
@@ -20,6 +20,10 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -30,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class HttpSchemaRegistryClientTest {
@@ -312,5 +317,64 @@ class HttpSchemaRegistryClientTest {
   void noAuthWhenAuthTypeIsBlankEvenWithToken() {
     assertThatCode(() -> new HttpSchemaRegistryClient(REGISTRY_URL, "   ", "irrelevant-token"))
         .doesNotThrowAnyException();
+  }
+
+  // ── TLS warnings (T07 / CWE-319) ──────────────────────────────────────────
+
+  private ListAppender<ILoggingEvent> attachAppender() {
+    Logger logger = (Logger) LoggerFactory.getLogger(HttpSchemaRegistryClient.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    return appender;
+  }
+
+  private void detachAppender(ListAppender<ILoggingEvent> appender) {
+    Logger logger = (Logger) LoggerFactory.getLogger(HttpSchemaRegistryClient.class);
+    logger.detachAppender(appender);
+    appender.stop();
+  }
+
+  @Test
+  void shouldWarnWhenAuthConfiguredOverPlainHttp() {
+    ListAppender<ILoggingEvent> appender = attachAppender();
+    try {
+      new HttpSchemaRegistryClient(REGISTRY_URL, "bearer", "super-secret-token");
+
+      assertThat(appender.list)
+          .anySatisfy(
+              event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                assertThat(event.getFormattedMessage())
+                    .contains("plain http")
+                    .doesNotContain("super-secret-token");
+              });
+    } finally {
+      detachAppender(appender);
+    }
+  }
+
+  @Test
+  void shouldNotWarnWhenNoAuthConfiguredOverPlainHttp() {
+    ListAppender<ILoggingEvent> appender = attachAppender();
+    try {
+      new HttpSchemaRegistryClient(REGISTRY_URL, (String) null, null);
+
+      assertThat(appender.list).noneMatch(event -> event.getLevel() == Level.WARN);
+    } finally {
+      detachAppender(appender);
+    }
+  }
+
+  @Test
+  void shouldNotWarnWhenAuthConfiguredOverHttps() {
+    ListAppender<ILoggingEvent> appender = attachAppender();
+    try {
+      new HttpSchemaRegistryClient("https://registry:8081", "bearer", "super-secret-token");
+
+      assertThat(appender.list).noneMatch(event -> event.getLevel() == Level.WARN);
+    } finally {
+      detachAppender(appender);
+    }
   }
 }

--- a/schema/build.gradle.kts
+++ b/schema/build.gradle.kts
@@ -22,4 +22,7 @@ dependencies {
     // Integration test containers
     testImplementation(libs.testcontainers.vault)
     testImplementation(libs.testcontainers.localstack)
+
+    // Logback test appender for asserting on WARN log output
+    testImplementation(libs.logback.classic)
 }

--- a/schema/src/main/java/com/datagenerator/schema/secret/VaultSecretResolver.java
+++ b/schema/src/main/java/com/datagenerator/schema/secret/VaultSecretResolver.java
@@ -78,6 +78,12 @@ public final class VaultSecretResolver implements SecretResolver {
       throw new SecretResolutionException("vault_addr must not be null or blank");
     }
     UrlValidator.validate(addr, "Vault address");
+    if (!UrlValidator.isHttps(addr)) {
+      log.warn(
+          "Sending the Vault token over plain http to {} — use https to protect the token in "
+              + "transit",
+          addr);
+    }
     this.vaultAddr = addr.endsWith("/") ? addr.substring(0, addr.length() - 1) : addr;
     this.namespace = namespace;
     this.httpClient = client;

--- a/schema/src/test/java/com/datagenerator/schema/secret/VaultSecretResolverTest.java
+++ b/schema/src/test/java/com/datagenerator/schema/secret/VaultSecretResolverTest.java
@@ -21,6 +21,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.datagenerator.schema.exception.SecretResolutionException;
 import java.io.IOException;
 import java.net.http.HttpClient;
@@ -36,6 +40,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("unchecked")
@@ -267,5 +272,52 @@ class VaultSecretResolverTest {
     assertThatThrownBy(() -> resolver.resolve("secret/data/app with space#key"))
         .isInstanceOf(SecretResolutionException.class)
         .hasMessageContaining("whitespace");
+  }
+
+  // ── TLS warnings (T07 / CWE-319) ──────────────────────────────────────────
+
+  private ListAppender<ILoggingEvent> attachAppender() {
+    Logger logger = (Logger) LoggerFactory.getLogger(VaultSecretResolver.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    return appender;
+  }
+
+  private void detachAppender(ListAppender<ILoggingEvent> appender) {
+    Logger logger = (Logger) LoggerFactory.getLogger(VaultSecretResolver.class);
+    logger.detachAppender(appender);
+    appender.stop();
+  }
+
+  @Test
+  void shouldWarnWhenVaultAddrIsPlainHttp() {
+    ListAppender<ILoggingEvent> appender = attachAppender();
+    try {
+      new VaultSecretResolver(VAULT_ADDR, null, mockClient, TEST_ENV);
+
+      assertThat(appender.list)
+          .anySatisfy(
+              event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                assertThat(event.getFormattedMessage())
+                    .contains("plain http")
+                    .doesNotContain(TEST_TOKEN);
+              });
+    } finally {
+      detachAppender(appender);
+    }
+  }
+
+  @Test
+  void shouldNotWarnWhenVaultAddrIsHttps() {
+    ListAppender<ILoggingEvent> appender = attachAppender();
+    try {
+      new VaultSecretResolver("https://vault:8200", null, mockClient, TEST_ENV);
+
+      assertThat(appender.list).noneMatch(event -> event.getLevel() == Level.WARN);
+    } finally {
+      detachAppender(appender);
+    }
   }
 }


### PR DESCRIPTION
CWE-319. UrlValidator javadoc promised an httpsOnly parameter that never existed; credentials (remote-seed bearer/basic/api-key, VAULT_TOKEN, Schema Registry tokens) could ride plain http silently. Added validate(url, context, httpsOnly) overload + isHttps helper; the three credentialed call sites now WARN (never logging the credential) when auth material is sent over http. Plain http without credentials stays allowed by design (internal deployments). Log-capture tests assert WARN level and zero credential leakage.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhgEN9eTdNgFzDnKKyVxxG