### PR TITLE
fix(generators): iban honours geolocation; add random_iban type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`random_iban` semantic type** (alias `random_locale_iban`) — emits an IBAN from a random country, preserving the previous locale-independent `iban` behavior for use cases such as foreign/cross-border destination accounts
+
+### Fixed
+- **`iban` now honours geolocation** (#173) — the `iban` type emitted IBANs from a random country regardless of `geolocation` (e.g. non-SEPA `KM`/`AO` IBANs under `geolocation: italy`), inconsistent with the locale-aware name/address/BIC. It now derives the ISO country from the resolved locale and uses Datafaker's country-scoped `finance().iban(country)` when supported (so `italy` → `IT…`), falling back to a random-country IBAN when the locale has no country or Datafaker has no format for it. Deterministic as before
+
 ### Security
 - **httpcore5-h2 5.4 → 5.4.3** — the Azure Key Vault seed chain (`azure-identity` → `msal4j`) pulled `httpcore5` 5.4.3 but left its `httpcore5-h2` sibling at 5.4, vulnerable to **CVE-2026-54428** (HPackDecoder unbounded header list) and **CVE-2026-54399** (unbounded HTTP header length). Both are fixed in 5.4.3; a `resolutionStrategy.force` now aligns `httpcore5-h2` with the patched core artifact across all configurations
 - **Four CPE false positives suppressed** (expiry 2026-10-10) after the 2026-07-12 scan re-flagged the Azure chain — CVE-2026-33117 (flaw is in keyvault-*keys* local crypto; this project uses keyvault-*secrets*), CVE-2026-54428/CVE-2026-54399 against classic `httpcore` 4.4.16 (HTTP/2 issue, 4.x has no HTTP/2), and CVE-2023-36415/CVE-2024-35255 (over-broad Azure/msal4j CPE match, confirmed in the 2026-07-07 review). README security section updated to match

--- a/core/src/main/java/com/datagenerator/core/registry/DatafakerRegistry.java
+++ b/core/src/main/java/com/datagenerator/core/registry/DatafakerRegistry.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.extern.slf4j.Slf4j;
 import net.datafaker.Faker;
+import net.datafaker.providers.base.Finance;
 
 /**
  * Thread-safe registry for custom Datafaker types. Allows runtime registration of new semantic data
@@ -139,7 +140,9 @@ public class DatafakerRegistry {
     register("company", (faker, random) -> faker.company().name());
     register("credit_card", (faker, random) -> faker.finance().creditCard());
     registerAlias("creditcard", "credit_card");
-    register("iban", (faker, random) -> faker.finance().iban());
+    register("iban", (faker, random) -> localeAwareIban(faker));
+    register("random_iban", (faker, random) -> faker.finance().iban());
+    registerAlias("random_locale_iban", "random_iban");
     register("currency", (faker, random) -> faker.money().currencyCode());
     register("price", (faker, random) -> faker.commerce().price());
     register("bic", (faker, random) -> conformantBic(faker));
@@ -202,6 +205,24 @@ public class DatafakerRegistry {
    */
   private static String conformantBic(Faker faker) {
     return faker.finance().bic().toUpperCase(Locale.ROOT);
+  }
+
+  /**
+   * Generate an IBAN for the Faker's configured locale.
+   *
+   * <p>Datafaker's no-arg {@code finance().iban()} returns an IBAN from a random country, ignoring
+   * the Faker locale. We derive the ISO country from the locale and use the country-scoped overload
+   * when Datafaker supports it, so {@code geolocation: italy} yields an {@code IT...} IBAN
+   * consistent with the locale-aware name/address/BIC. Falls back to the random-country form when
+   * the locale carries no country (language-only) or Datafaker has no IBAN format for it. The
+   * {@code random_iban} type preserves the deliberate random-country behavior.
+   */
+  private static String localeAwareIban(Faker faker) {
+    String country = faker.getContext().getLocale().getCountry().toUpperCase(Locale.ROOT);
+    if (!country.isBlank() && Finance.ibanSupportedCountries().contains(country)) {
+      return faker.finance().iban(country);
+    }
+    return faker.finance().iban();
   }
 
   /**

--- a/docs/DATAFAKER-COVERAGE.md
+++ b/docs/DATAFAKER-COVERAGE.md
@@ -6,7 +6,7 @@
 
 ---
 
-## Currently Implemented Types (48 canonical types + 33 aliases)
+## Currently Implemented Types (49 canonical types + 34 aliases)
 
 All types are registered in `DatafakerRegistry` (`core/src/main/java/.../registry/DatafakerRegistry.java`).
 Aliases are case-insensitive and normalized at lookup time.
@@ -50,13 +50,14 @@ Aliases are case-insensitive and normalized at lookup time.
 | `email` | `faker.internet().emailAddress()` | — |
 | `phone_number` | `faker.phoneNumber().phoneNumber()` | `phonenumber`, `phone` |
 
-### Finance & Business (9 types)
+### Finance & Business (10 types)
 
 | Type | Datafaker call | Aliases |
 |---|---|---|
 | `company` | `faker.company().name()` | — |
 | `credit_card` | `faker.finance().creditCard()` | `creditcard` |
-| `iban` | `faker.finance().iban()` | — |
+| `iban` | `faker.finance().iban(country)` — locale-aware: uses the locale's country when Datafaker supports it, else random-country | — |
+| `random_iban` | `faker.finance().iban()` — explicit random-country IBAN (e.g. cross-border destination accounts) | `random_locale_iban` |
 | `currency` | `faker.money().currencyCode()` | — |
 | `price` | `faker.commerce().price()` | — |
 | `bic` | `faker.finance().bic()` | `swift` |
@@ -254,7 +255,7 @@ can produce.
 | **Person & Identity** | 11 | ~13 | 85% |
 | **Address** | 11 | ~16 | 69% |
 | **Contact** | 2 | ~2 | 100% |
-| **Finance & Business** | 9 | ~17 | 53% |
+| **Finance & Business** | 10 | ~17 | 59% |
 | **Internet** | 5 | ~13 | 38% |
 | **Codes & Identifiers** | 2 | ~7 | 29% |
 | **Commerce** | 5 | ~5 | 100% |

--- a/generators/src/test/java/com/datagenerator/generators/semantic/DatafakerGeolocationTest.java
+++ b/generators/src/test/java/com/datagenerator/generators/semantic/DatafakerGeolocationTest.java
@@ -109,6 +109,56 @@ class DatafakerGeolocationTest {
   }
 
   // ==================================================================================
+  // IBAN LOCALE AWARENESS (issue #173)
+  // ==================================================================================
+
+  private static final String IBAN_PATTERN = "^[A-Z]{2}\\d{2}[A-Z0-9]+$";
+
+  @ParameterizedTest
+  @CsvSource({"italy, IT", "germany, DE", "france, FR"})
+  void shouldGenerateIbanForLocaleCountry(String geolocation, String expectedCountry) {
+    String iban = (String) generateWithContext(geolocation, new CustomDatafakerType("iban"));
+    assertThat(iban).isNotNull().matches(IBAN_PATTERN).startsWith(expectedCountry);
+  }
+
+  @Test
+  void shouldFallBackToValidIbanWhenLocaleCountryHasNoIbanFormat() {
+    // Japan (Locale.JAPAN, country JP) has no IBAN format in Datafaker → falls back to a
+    // random-country IBAN rather than throwing. Still a structurally valid IBAN.
+    String iban = (String) generateWithContext("japan", new CustomDatafakerType("iban"));
+    assertThat(iban).isNotNull().matches(IBAN_PATTERN);
+  }
+
+  @Test
+  void shouldGenerateValidRandomIbanIndependentOfLocale() {
+    String iban = (String) generateWithContext("italy", new CustomDatafakerType("random_iban"));
+    assertThat(iban).isNotNull().matches(IBAN_PATTERN);
+  }
+
+  @Test
+  void shouldResolveRandomIbanAlias() {
+    String iban =
+        (String) generateWithContext("italy", new CustomDatafakerType("random_locale_iban"));
+    assertThat(iban).isNotNull().matches(IBAN_PATTERN);
+  }
+
+  @Test
+  void shouldGenerateIbanDeterministicallyForSameLocaleAndSeed() {
+    String first = (String) generateWithContext("italy", new CustomDatafakerType("iban"));
+    FakerCache.clear();
+    String second = (String) generateWithContext("italy", new CustomDatafakerType("iban"));
+    assertThat(second).isEqualTo(first);
+  }
+
+  @Test
+  void shouldGenerateRandomIbanDeterministicallyForSameSeed() {
+    String first = (String) generateWithContext("italy", new CustomDatafakerType("random_iban"));
+    FakerCache.clear();
+    String second = (String) generateWithContext("italy", new CustomDatafakerType("random_iban"));
+    assertThat(second).isEqualTo(first);
+  }
+
+  // ==================================================================================
   // ALL SEMANTIC TYPES COVERAGE - Test every semantic type we support
   // ==================================================================================
 

--- a/use-cases/dora-gdpr-sepa-payments/README.md
+++ b/use-cases/dora-gdpr-sepa-payments/README.md
@@ -66,6 +66,10 @@ they must equal the batch contents, and a per-row generator cannot correlate the
 `ACSP` AcceptedSettlementInProcess · `ACSC` AcceptedSettlementCompleted · `ACWC` AcceptedWithChange ·
 `PDNG` Pending · `RJCT` Rejected.
 
+Under `geolocation: italy` the `iban` type emits locale-correct Italian (`IT…`) IBANs, matching the
+Italian names, `country`, and BIC. For deliberately foreign/cross-border destination accounts, use
+the `random_iban` type instead (random-country IBAN).
+
 ## Run it
 
 No infrastructure required — writes JSON to a file. **Run from the repository root** (the output
@@ -93,10 +97,6 @@ millions of rows into a real test database instead of a file.
 
 - **Models the payment *data*, not the `pain.001` XML envelope.** SeedStream emits JSON/CSV/Avro,
   not ISO 20022 XML. A `pain.001` XML serializer would be a separate feature.
-- **IBANs are valid IBANs but not restricted to the SEPA zone / Italy.** Datafaker's no-arg
-  `iban()` returns IBANs from a random country (e.g. `DE`, `ES`, but also non-SEPA ones), regardless
-  of `geolocation`. Names, `country`, and BIC do honour the Italian locale. Tracked as a bug
-  ([#173](https://github.com/mferretti/SeedStream/issues/173)).
 - **`msg_id` / `end_to_end_id` are random alphanumeric** (`char`), not structured ISO references.
   Config-declarable regex/patterned generators
   ([#174](https://github.com/mferretti/SeedStream/issues/174)) would let these match real reference


### PR DESCRIPTION
## Problem

`iban` emitted IBANs from a random country regardless of `geolocation` — e.g. non-SEPA `KM`/`AO` IBANs under `geolocation: italy`, inconsistent with the locale-aware `full_name`/`country_code`/`bic`. Discovered building the SEPA use case (#83). Datafaker builds the Faker *with* the locale, but no-arg `finance().iban()` ignores it.

## Fix

- **`iban` is now locale-aware**: derives the ISO country from the resolved locale and calls the country-scoped `finance().iban(country)` when Datafaker supports it (`italy` → `IT…`), falling back to the random-country form when the locale carries no country or Datafaker has no format for it. Membership-checked via static `Finance.ibanSupportedCountries()` — no broad exception catch. Deterministic as before.
- **New `random_iban`** (alias `random_locale_iban`): preserves the explicit random-country behavior for foreign/cross-border destination accounts.

Single production file (`DatafakerRegistry.java`); no signature changes.

## Not systemic

Most Datafaker types honour locale automatically via the locale-bound Faker instance (there is no arg to pass). Audited the algorithmic providers: `ssn` already locale-dispatches; `credit_card`/`stock`/`isbn` are inherently locale-independent; **`bic` and `currency` do ignore geolocation but have no country/locale overload** to force it → separate follow-up (needs #174 patterned generators), not this PR.

## Tests

`DatafakerGeolocationTest`: `iban` → IT/DE/FR, JP fallback (no throw), `random_iban` + alias, determinism for both. `:core:test :generators:test` green; spotless clean.

## Verification

- SEPA example (`use-cases/dora-gdpr-sepa-payments/`) IBANs now all `IT`; byte-for-byte reproducible.
- **Local homelab Sonar gate OK** — new_violations 0, new_coverage 90.5%, duplication 0.0%.

## Docs

`docs/DATAFAKER-COVERAGE.md` (iban row + `random_iban`), SEPA use-case README (iban locale-correct; `random_iban` note), `CHANGELOG.md` (Added + Fixed).

Closes #173 · cross-ref #175 (depends on this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

