### PR TITLE
feat(generators): add sepa_iban type; SEPA-wide creditor in use case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **`random_iban` semantic type** (alias `random_locale_iban`) — emits an IBAN from a random country, preserving the previous locale-independent `iban` behavior for use cases such as foreign/cross-border destination accounts
+- **`sepa_iban` semantic type** — emits an IBAN from a random SEPA-zone country (locale-independent). Used by the SEPA use case for the creditor (destination) account, where the counterparty can be any SEPA country while the debtor stays domestic
 
 ### Fixed
 - **`iban` now honours geolocation** (#173) — the `iban` type emitted IBANs from a random country regardless of `geolocation` (e.g. non-SEPA `KM`/`AO` IBANs under `geolocation: italy`), inconsistent with the locale-aware name/address/BIC. It now derives the ISO country from the resolved locale and uses Datafaker's country-scoped `finance().iban(country)` when supported (so `italy` → `IT…`), falling back to a random-country IBAN when the locale has no country or Datafaker has no format for it. Deterministic as before

--- a/config/README.md
+++ b/config/README.md
@@ -640,11 +640,17 @@ username:   { datatype: username }
 
 **Finance**
 ```yaml
-iban:        { datatype: iban }           # alias: bic, swift
+iban:        { datatype: iban }           # locale-aware IBAN: geolocation country (italy → IT…)
+random_iban: { datatype: random_iban }    # IBAN from any country worldwide (alias: random_locale_iban)
+sepa_iban:   { datatype: sepa_iban }      # IBAN from a random SEPA-zone country
+bic:         { datatype: bic }            # ISO 9362 bank identifier (alias: swift)
 credit_card: { datatype: credit_card }
 ```
 
-**48+ types total** with 20+ aliases. Add more without code via `--faker-types <file>` — map any no-arg Datafaker method chain (e.g. `beer_style: beer.style` → `faker.beer().style()`). Only parameterized providers (ranges, `options`, `regexify`, bounded dates) or non-String formatting need a Java lambda via `DatafakerRegistry.register`.
+`iban` honours `geolocation` (like names/addresses). `random_iban` and `sepa_iban` are
+locale-independent — use them for foreign or SEPA-wide counterparty accounts respectively.
+
+**50+ types total** with 20+ aliases. Add more without code via `--faker-types <file>` — map any no-arg Datafaker method chain (e.g. `beer_style: beer.style` → `faker.beer().style()`). Only parameterized providers (ranges, `options`, `regexify`, bounded dates) or non-String formatting need a Java lambda via `DatafakerRegistry.register`.
 See [generators module](../generators/) for the complete list.
 
 ### Composite Types

--- a/core/src/main/java/com/datagenerator/core/registry/DatafakerRegistry.java
+++ b/core/src/main/java/com/datagenerator/core/registry/DatafakerRegistry.java
@@ -66,6 +66,9 @@ public class DatafakerRegistry {
   private static final String TYPE_PRODUCT_NAME = "product_name";
   private static final String TYPE_PROMOTION_CODE = "promotion_code";
 
+  /** SEPA-zone countries (ISO 3166-1 alpha-2) that Datafaker can emit an IBAN for. */
+  private static final List<String> SEPA_SUPPORTED = sepaSupported();
+
   /** Functional interface for Datafaker type generators. */
   @FunctionalInterface
   public interface DatafakerFunction {
@@ -143,6 +146,7 @@ public class DatafakerRegistry {
     register("iban", (faker, random) -> localeAwareIban(faker));
     register("random_iban", (faker, random) -> faker.finance().iban());
     registerAlias("random_locale_iban", "random_iban");
+    register("sepa_iban", DatafakerRegistry::sepaIban);
     register("currency", (faker, random) -> faker.money().currencyCode());
     register("price", (faker, random) -> faker.commerce().price());
     register("bic", (faker, random) -> conformantBic(faker));
@@ -223,6 +227,37 @@ public class DatafakerRegistry {
       return faker.finance().iban(country);
     }
     return faker.finance().iban();
+  }
+
+  /**
+   * Generate an IBAN from a random SEPA-zone country, independent of the Faker locale.
+   *
+   * <p>Unlike {@code iban} (locale country) and {@code random_iban} (any country worldwide), this
+   * restricts the country to the SEPA zone — the correct scope for a SEPA credit-transfer
+   * destination account. The country is picked from {@link #SEPA_SUPPORTED} via the seeded {@code
+   * random}, keeping generation deterministic. Falls back to a random-country IBAN only in the
+   * unlikely case Datafaker supports none of the SEPA countries.
+   */
+  private static String sepaIban(Faker faker, Random random) {
+    if (SEPA_SUPPORTED.isEmpty()) {
+      return faker.finance().iban();
+    }
+    String country = SEPA_SUPPORTED.get(random.nextInt(SEPA_SUPPORTED.size()));
+    return faker.finance().iban(country);
+  }
+
+  /**
+   * SEPA member countries (ISO 3166-1 alpha-2) intersected with the countries Datafaker can emit an
+   * IBAN for, so {@link #sepaIban} never calls an unsupported country.
+   */
+  private static List<String> sepaSupported() {
+    Set<String> sepa =
+        Set.of(
+            "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "GR", "HU", "IE",
+            "IT", "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK", "SI", "ES", "SE", // EU27
+            "IS", "LI", "NO", // EEA
+            "CH", "MC", "SM", "GB", "GI", "AD", "VA"); // other SEPA participants
+    return sepa.stream().filter(Finance.ibanSupportedCountries()::contains).sorted().toList();
   }
 
   /**

--- a/core/src/main/java/com/datagenerator/core/registry/DatafakerRegistry.java
+++ b/core/src/main/java/com/datagenerator/core/registry/DatafakerRegistry.java
@@ -239,11 +239,18 @@ public class DatafakerRegistry {
    * unlikely case Datafaker supports none of the SEPA countries.
    */
   private static String sepaIban(Faker faker, Random random) {
-    if (SEPA_SUPPORTED.isEmpty()) {
+    return sepaIban(faker, random, SEPA_SUPPORTED);
+  }
+
+  /**
+   * Pick a random SEPA-zone IBAN from {@code sepaCountries}. Package-private with the country list
+   * injected so both branches (normal + the defensive empty fallback) are testable.
+   */
+  static String sepaIban(Faker faker, Random random, List<String> sepaCountries) {
+    if (sepaCountries.isEmpty()) {
       return faker.finance().iban();
     }
-    String country = SEPA_SUPPORTED.get(random.nextInt(SEPA_SUPPORTED.size()));
-    return faker.finance().iban(country);
+    return faker.finance().iban(sepaCountries.get(random.nextInt(sepaCountries.size())));
   }
 
   /**

--- a/core/src/test/java/com/datagenerator/core/registry/DatafakerRegistryTest.java
+++ b/core/src/test/java/com/datagenerator/core/registry/DatafakerRegistryTest.java
@@ -18,6 +18,7 @@ package com.datagenerator.core.registry;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 import java.util.Set;
@@ -247,12 +248,28 @@ class DatafakerRegistryTest {
     assertThat(DatafakerRegistry.generate("company", FAKER, RANDOM)).isNotBlank();
     assertThat(DatafakerRegistry.generate("credit_card", FAKER, RANDOM)).isNotBlank();
     assertThat(DatafakerRegistry.generate("iban", FAKER, RANDOM)).isNotBlank();
+    assertThat(DatafakerRegistry.generate("random_iban", FAKER, RANDOM)).isNotBlank();
+    assertThat(DatafakerRegistry.generate("sepa_iban", FAKER, RANDOM)).isNotBlank();
     assertThat(DatafakerRegistry.generate("currency", FAKER, RANDOM)).isNotBlank();
     assertThat(DatafakerRegistry.generate("price", FAKER, RANDOM)).isNotBlank();
     assertThat(DatafakerRegistry.generate("bic", FAKER, RANDOM)).isNotBlank();
     assertThat(DatafakerRegistry.generate("cvv", FAKER, RANDOM)).isNotBlank();
     assertThat(DatafakerRegistry.generate("credit_card_type", FAKER, RANDOM)).isNotBlank();
     assertThat(DatafakerRegistry.generate("stock_market", FAKER, RANDOM)).isNotBlank();
+  }
+
+  @Test
+  void shouldGenerateSepaIbanFromProvidedCountries() {
+    String iban = DatafakerRegistry.sepaIban(FAKER, RANDOM, List.of("IT", "DE", "FR"));
+    assertThat(iban).matches("^[A-Z]{2}\\d{2}[A-Z0-9]+$");
+    assertThat(iban.substring(0, 2)).isIn("IT", "DE", "FR");
+  }
+
+  @Test
+  void shouldFallBackToRandomIbanWhenNoSepaCountries() {
+    // Defensive branch: empty SEPA∩supported set → random-country IBAN, not an exception.
+    String iban = DatafakerRegistry.sepaIban(FAKER, RANDOM, List.of());
+    assertThat(iban).matches("^[A-Z]{2}\\d{2}[A-Z0-9]+$");
   }
 
   @Test

--- a/docs/DATAFAKER-COVERAGE.md
+++ b/docs/DATAFAKER-COVERAGE.md
@@ -6,7 +6,7 @@
 
 ---
 
-## Currently Implemented Types (49 canonical types + 34 aliases)
+## Currently Implemented Types (50 canonical types + 34 aliases)
 
 All types are registered in `DatafakerRegistry` (`core/src/main/java/.../registry/DatafakerRegistry.java`).
 Aliases are case-insensitive and normalized at lookup time.
@@ -50,7 +50,7 @@ Aliases are case-insensitive and normalized at lookup time.
 | `email` | `faker.internet().emailAddress()` | — |
 | `phone_number` | `faker.phoneNumber().phoneNumber()` | `phonenumber`, `phone` |
 
-### Finance & Business (10 types)
+### Finance & Business (11 types)
 
 | Type | Datafaker call | Aliases |
 |---|---|---|
@@ -58,6 +58,7 @@ Aliases are case-insensitive and normalized at lookup time.
 | `credit_card` | `faker.finance().creditCard()` | `creditcard` |
 | `iban` | `faker.finance().iban(country)` — locale-aware: uses the locale's country when Datafaker supports it, else random-country | — |
 | `random_iban` | `faker.finance().iban()` — explicit random-country IBAN (e.g. cross-border destination accounts) | `random_locale_iban` |
+| `sepa_iban` | `faker.finance().iban(country)` for a random **SEPA-zone** country — locale-independent | — |
 | `currency` | `faker.money().currencyCode()` | — |
 | `price` | `faker.commerce().price()` | — |
 | `bic` | `faker.finance().bic()` | `swift` |
@@ -255,7 +256,7 @@ can produce.
 | **Person & Identity** | 11 | ~13 | 85% |
 | **Address** | 11 | ~16 | 69% |
 | **Contact** | 2 | ~2 | 100% |
-| **Finance & Business** | 10 | ~17 | 59% |
+| **Finance & Business** | 11 | ~17 | 65% |
 | **Internet** | 5 | ~13 | 38% |
 | **Codes & Identifiers** | 2 | ~7 | 29% |
 | **Commerce** | 5 | ~5 | 100% |

--- a/generators/src/test/java/com/datagenerator/generators/semantic/DatafakerGeolocationTest.java
+++ b/generators/src/test/java/com/datagenerator/generators/semantic/DatafakerGeolocationTest.java
@@ -25,9 +25,11 @@ import com.datagenerator.generators.DataGeneratorFactory;
 import com.datagenerator.generators.GeneratorContext;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -142,20 +144,35 @@ class DatafakerGeolocationTest {
     assertThat(iban).isNotNull().matches(IBAN_PATTERN);
   }
 
-  @Test
-  void shouldGenerateIbanDeterministicallyForSameLocaleAndSeed() {
-    String first = (String) generateWithContext("italy", new CustomDatafakerType("iban"));
+  @ParameterizedTest
+  @ValueSource(strings = {"iban", "random_iban", "sepa_iban"})
+  void shouldGenerateIbanTypeDeterministicallyForSameSeed(String ibanType) {
+    String first = (String) generateWithContext("italy", new CustomDatafakerType(ibanType));
     FakerCache.clear();
-    String second = (String) generateWithContext("italy", new CustomDatafakerType("iban"));
+    String second = (String) generateWithContext("italy", new CustomDatafakerType(ibanType));
     assertThat(second).isEqualTo(first);
   }
 
+  private static final Set<String> SEPA_COUNTRIES =
+      Set.of(
+          "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "GR", "HU", "IE", "IT",
+          "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK", "SI", "ES", "SE", "IS", "LI", "NO",
+          "CH", "MC", "SM", "GB", "GI", "AD", "VA");
+
   @Test
-  void shouldGenerateRandomIbanDeterministicallyForSameSeed() {
-    String first = (String) generateWithContext("italy", new CustomDatafakerType("random_iban"));
-    FakerCache.clear();
-    String second = (String) generateWithContext("italy", new CustomDatafakerType("random_iban"));
-    assertThat(second).isEqualTo(first);
+  void shouldGenerateSepaIbanWithinSepaZone() {
+    // Multiple draws under one context (seeded Random advances) → varied SEPA countries.
+    Set<String> countries = new HashSet<>();
+    try (var ctx = GeneratorContext.enter(factory, "italy")) {
+      Random random = new Random(12345L);
+      CustomDatafakerType type = new CustomDatafakerType("sepa_iban");
+      for (int i = 0; i < 50; i++) {
+        String iban = (String) generator.generate(random, type);
+        assertThat(iban).matches(IBAN_PATTERN);
+        countries.add(iban.substring(0, 2));
+      }
+    }
+    assertThat(countries).isSubsetOf(SEPA_COUNTRIES).hasSizeGreaterThan(1);
   }
 
   // ==================================================================================

--- a/use-cases/dora-gdpr-sepa-payments/README.md
+++ b/use-cases/dora-gdpr-sepa-payments/README.md
@@ -50,25 +50,28 @@ they must equal the batch contents, and a per-row generator cannot correlate the
 | `category_purpose_code` | `enum[SALA,SUPP,TAXS,TRAD,CASH]` | `CtgyPurp/Cd` | ISO ExternalCategoryPurpose |
 | `remittance_info` | `lorem_sentence` | `RmtInf/Ustrd` | readable text, ≤ 140 chars |
 | `status` | `enum[ACTC,ACCP,ACSP,ACSC,ACWC,PDNG,RJCT]` | `pain.002` `TxSts` | ISO ExternalPaymentTransactionStatus |
-| `debtor` | `object[sct_party]` | `Dbtr` + `DbtrAcct` + `DbtrAgt` | nested |
-| `creditor` | `object[sct_party]` | `Cdtr` + `CdtrAcct` + `CdtrAgt` | nested |
+| `debtor` | `object[sct_party]` | `Dbtr` + `DbtrAcct` + `DbtrAgt` | Italian originator |
+| `creditor` | `object[sct_creditor]` | `Cdtr` + `CdtrAcct` + `CdtrAgt` | SEPA-wide destination |
 
-`structures/sct_party.yaml` (nested party):
+`structures/sct_party.yaml` (debtor / originator) and `structures/sct_creditor.yaml` (creditor /
+destination) share the same fields; they differ only in the IBAN scope:
 
-| field | datatype | ISO 20022 element |
-|---|---|---|
-| `name` | `full_name` | `Dbtr/Cdtr` `Nm` (max 70) |
-| `iban` | `iban` | `{Dbtr,Cdtr}Acct/Id/IBAN` |
-| `bic` | `bic` | `{Dbtr,Cdtr}Agt/FinInstnId/BICFI` (8 or 11 chars) |
-| `country` | `country_code` | `PstlAdr/Ctry` (ISO 3166 alpha-2) |
+| field | debtor `datatype` | creditor `datatype` | ISO 20022 element |
+|---|---|---|---|
+| `name` | `full_name` | `full_name` | `Nm` (max 70) |
+| `iban` | `iban` (locale → `IT`) | `sepa_iban` (random SEPA country) | `Acct/Id/IBAN` |
+| `bic` | `bic` | `bic` | `Agt/FinInstnId/BICFI` (8 or 11 chars) |
+| `country` | `country_code` | `country_code` | `PstlAdr/Ctry` (ISO 3166 alpha-2) |
 
 **`pain.002` status codes:** `ACTC` AcceptedTechnicalValidation · `ACCP` AcceptedCustomerProfile ·
 `ACSP` AcceptedSettlementInProcess · `ACSC` AcceptedSettlementCompleted · `ACWC` AcceptedWithChange ·
 `PDNG` Pending · `RJCT` Rejected.
 
-Under `geolocation: italy` the `iban` type emits locale-correct Italian (`IT…`) IBANs, matching the
-Italian names, `country`, and BIC. For deliberately foreign/cross-border destination accounts, use
-the `random_iban` type instead (random-country IBAN).
+A SEPA credit transfer originates domestically but can settle anywhere in the SEPA zone. The
+**debtor** uses the locale-aware `iban` type (`geolocation: italy` → Italian `IT…` account,
+matching the Italian name/BIC). The **creditor** uses `sepa_iban` — a random IBAN from a SEPA-zone
+country (DE, FR, ES, NL, …, occasionally IT for a domestic transfer). For accounts *outside* SEPA,
+the `random_iban` type (any country worldwide) is also available.
 
 ## Run it
 
@@ -103,4 +106,5 @@ millions of rows into a real test database instead of a file.
   formats ([#175](https://github.com/mferretti/SeedStream/issues/175)). `remittance_info` uses
   `lorem_sentence` placeholder text, not real remittance wording.
 - **Fields are independent** — there is no cross-field correlation (e.g. `requested_execution_date`
-  is not guaranteed ≥ `creation_date_time`).
+  is not guaranteed ≥ `creation_date_time`; the creditor's `name`/`country` are Italian-locale and
+  need not match its `sepa_iban` country).

--- a/use-cases/dora-gdpr-sepa-payments/structures/sct_creditor.yaml
+++ b/use-cases/dora-gdpr-sepa-payments/structures/sct_creditor.yaml
@@ -1,0 +1,14 @@
+# ISO 20022 SEPA creditor (destination) party — name + account IBAN + agent BIC + country.
+# Unlike the debtor (sct_party, Italian originator), the creditor account can be anywhere in the
+# SEPA zone, so `iban` uses `sepa_iban` (random SEPA-zone country) rather than the locale IBAN.
+name: sct_creditor
+geolocation: italy
+data:
+  name: # Cdtr Nm (max 70)
+    datatype: full_name
+  iban: # CdtrAcct/Id/IBAN — random SEPA-zone IBAN (destination may be any SEPA country)
+    datatype: sepa_iban
+  bic: # CdtrAgt/FinInstnId/BICFI — 8 or 11 chars
+    datatype: bic
+  country: # PstlAdr/Ctry — ISO 3166 alpha-2
+    datatype: country_code

--- a/use-cases/dora-gdpr-sepa-payments/structures/sct_party.yaml
+++ b/use-cases/dora-gdpr-sepa-payments/structures/sct_party.yaml
@@ -1,10 +1,12 @@
-# ISO 20022 SEPA party (debtor / creditor) — name + account IBAN + agent BIC + country.
+# ISO 20022 SEPA debtor (originator) party — name + account IBAN + agent BIC + country.
+# The originator is the Italian bank's customer, so `iban` is the locale IBAN (IT). The creditor
+# (destination) uses sct_creditor with sepa_iban instead.
 name: sct_party
 geolocation: italy
 data:
-  name: # Dbtr/Cdtr Nm (max 70) — Italian names under geolocation italy
+  name: # Dbtr Nm (max 70) — Italian names under geolocation italy
     datatype: full_name
-  iban: # {Dbtr,Cdtr}Acct/Id/IBAN — IT-format IBAN under Locale.ITALY
+  iban: # DbtrAcct/Id/IBAN — IT-format IBAN under Locale.ITALY
     datatype: iban
   bic: # {Dbtr,Cdtr}Agt/FinInstnId/BICFI — 8 or 11 chars
     datatype: bic

--- a/use-cases/dora-gdpr-sepa-payments/structures/sepa_credit_transfer.yaml
+++ b/use-cases/dora-gdpr-sepa-payments/structures/sepa_credit_transfer.yaml
@@ -27,7 +27,7 @@ data:
     datatype: lorem_sentence
   status: # pain.002 TxSts — ISO ExternalPaymentTransactionStatus
     datatype: enum[ACTC,ACCP,ACSP,ACSC,ACWC,PDNG,RJCT]
-  debtor: # Dbtr + DbtrAcct + DbtrAgt
+  debtor: # Dbtr + DbtrAcct + DbtrAgt — Italian originator (locale IBAN → IT)
     datatype: object[sct_party]
-  creditor: # Cdtr + CdtrAcct + CdtrAgt
-    datatype: object[sct_party]
+  creditor: # Cdtr + CdtrAcct + CdtrAgt — SEPA-wide destination (sepa_iban)
+    datatype: object[sct_creditor]


### PR DESCRIPTION
## Problem

After #173 the `iban` type honours `geolocation`, so both parties in the SEPA example resolved to Italian `IT…` IBANs. A real SEPA credit transfer originates domestically but can settle in **any SEPA-zone country**, so the creditor (destination) needs a SEPA-wide IBAN. Neither existing type fits: `iban` is locale-only (IT), `random_iban` is worldwide (incl. non-SEPA like KM/AO).

## Change

- **New `sepa_iban` semantic type** — IBAN from a random SEPA-zone country: curated SEPA member set (ISO 3166 alpha-2) intersected with Datafaker's `Finance.ibanSupportedCountries()`, country picked via the seeded `Random` (deterministic), `finance().iban(country)`.
- **Use case** — split the shared party: `sct_party` stays the debtor (locale `IT`), new `sct_creditor` uses `sepa_iban`; `sepa_credit_transfer.creditor` → `object[sct_creditor]`.

## Tests

`DatafakerGeolocationTest`: `sepa_iban` ⊆ SEPA zone + variety; determinism parameterized across `iban`/`random_iban`/`sepa_iban`. `:core:test :generators:test` green; spotless clean.

## Verification

- Debtor IBANs all `IT`; creditor spans **24 SEPA countries** (⊆ zone); byte-for-byte reproducible.
- **Local homelab Sonar gate OK** — new_violations 0, new_coverage 89.5%, duplication 0.0%.

## Docs

`docs/DATAFAKER-COVERAGE.md` (row + counts), `config/README.md` type reference (three IBAN modes; fixed a stale iban alias note), SEPA use-case README (party tables, honest limits), `CHANGELOG.md`.

Closes #178 · builds on #173