### PR TITLE
chore(deps): batch dependency bumps (#181–#188)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
     - name: Set up JDK 21
-      uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
+      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
     - name: Set up JDK 21
-      uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
+      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
     - name: Set up JDK 21
-      uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
+      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
     - name: Set up JDK 21
-      uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
+      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,7 +116,7 @@ subprojects {
             // constraint) while runtimeClasspath correctly overrides to 2.22.0. 2.20.0 carries
             // CVE-2026-54512/54513 (CVSS > 7) + 54514; force the catalog version everywhere so
             // OWASP DC never sees 2.20.0 on any configuration.
-            "com.fasterxml.jackson.core:jackson-databind:2.22.0"
+            "com.fasterxml.jackson.core:jackson-databind:2.22.1"
         )
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,10 +3,10 @@
 
 [versions]
 # Core Libraries
-jackson = "2.22.0"
+jackson = "2.22.1"
 lombok = "1.18.46"
 slf4j = "2.0.18"
-logback = "1.5.37"
+logback = "1.5.38"
 picocli = "4.7.7"
 
 # Data Generation
@@ -34,13 +34,13 @@ kafka = "4.3.1"
 
 # Database
 hikaricp = "7.1.0"
-postgresql = "42.7.12"
+postgresql = "42.7.13"
 mysql-connector = "8.4.0"
 ojdbc = "23.26.2.0.0"
 mssql-jdbc = "13.4.0.jre11"
 
 # Testing
-junit = "6.1.1"
+junit = "6.1.2"
 h2 = "2.4.240"
 mockito = "5.21.0"
 assertj = "3.27.7"
@@ -48,10 +48,10 @@ testcontainers = "1.21.4"
 awaitility = "4.3.0"  # Updated from 4.2.2
 
 # Security
-aws-sdk = "2.47.1"
+aws-sdk = "2.47.5"
 azure-keyvault-secrets = "4.11.1"
 azure-identity = "1.18.4"
-gcp-secretmanager = "2.93.0"
+gcp-secretmanager = "2.94.0"
 
 # Security Constraints (for dependency-check)
 log4j = "2.26.0"
@@ -60,7 +60,7 @@ log4j = "2.26.0"
 jmh-plugin = "0.7.3"
 lombok-plugin = "9.5.0"
 spotless-plugin = "8.8.0"
-spotbugs-plugin = "6.5.8"
+spotbugs-plugin = "6.5.9"
 dependency-check-plugin = "12.2.2"
 sonarqube-plugin = "7.3.1.8318"
 


### PR DESCRIPTION
Combines the eight open Dependabot PRs into one branch so the suite runs a **single CI cycle instead of eight**.

## Bumps
| PR | Bump |
|---|---|
| #181 | jackson 2.22.0 → 2.22.1 (+ `jackson-databind` force in `build.gradle.kts` → 2.22.1) |
| #188 | postgresql 42.7.12 → 42.7.13 |
| #184 | aws secretsmanager 2.47.1 → 2.47.5 |
| #183 | google-cloud-secretmanager 2.93.0 → 2.94.0 |
| #186 | logback-classic 1.5.37 → 1.5.38 |
| #187 | junit-bom → 6.1.2 |
| #185 | spotbugs plugin 6.5.8 → 6.5.9 |
| #182 | actions/setup-java 5.4.0 → 5.5.0 (SHA-pinned) |

## Why the jackson force also moves
`build.gradle.kts` forces `jackson-databind` on all configurations (OWASP fix). Left at 2.22.0 it would pin databind *below* the other jackson artifacts (2.22.1) → split version. Bumped to 2.22.1; verified `jackson-databind` resolves to 2.22.1 on every configuration (lifts a transitive 2.20.0).

## Regression (local, Docker)
Full build + unit green. Integration tests pass for every bumped runtime lib:
- **PostgresIT 11/11** (+ MySQL, nested, reference)
- **AwsSecretsManagerResolverIT 6/6** (LocalStack, 2.47.5)
- **GoogleSecretManagerResolverIT 6/6** (2.94.0)

Vault ITs fail only on a missing `VAULT_TOKEN` (environment, not deps) — and CI runs unit tests only, so they don't gate this PR.

## Security / CVE
Force-pins kept as-is (only jackson moved). The 4 active OWASP suppressions are Azure-chain CPE false-positives untouched by these bumps, so none are expected to clear — the **Security Scan** job is the authoritative OWASP/NVD check (it holds the NVD key).

Closes #181, #182, #183, #184, #185, #186, #187, #188