### PR TITLE
feat(cli): add ./seedstream launcher wrapper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       # Stable, unversioned filenames so README links under /releases/latest/download/
       # never need bumping per release.
       run: |
-        cp "cli/build/distributions/cli-${{ steps.version.outputs.VERSION }}.zip" cli-latest.zip
+        cp "cli/build/distributions/seedstream-${{ steps.version.outputs.VERSION }}.zip" seedstream-latest.zip
         cp "cli/build/libs/seedstream-${{ steps.version.outputs.VERSION }}.jar" seedstream-latest.jar
 
     - name: Create GitHub Release
@@ -50,9 +50,9 @@ jobs:
         name: "SeedStream ${{ github.ref_name }}"
         body_path: CHANGELOG.md
         files: |
-          cli/build/distributions/cli-${{ steps.version.outputs.VERSION }}.zip
+          cli/build/distributions/seedstream-${{ steps.version.outputs.VERSION }}.zip
           cli/build/libs/seedstream-${{ steps.version.outputs.VERSION }}.jar
-          cli-latest.zip
+          seedstream-latest.zip
           seedstream-latest.jar
         draft: false
         prerelease: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,8 +87,8 @@ LABEL org.opencontainers.image.title="SeedStream" \
 
 WORKDIR /work
 
-# Application: bin/cli + lib/*.jar + extras/ (classpath dir for runtime JDBC drivers)
-COPY --from=build /src/cli/build/install/cli /opt/seedstream
+# Application: bin/seedstream + lib/*.jar + extras/ (classpath dir for runtime JDBC drivers)
+COPY --from=build /src/cli/build/install/seedstream /opt/seedstream
 # Curated sample config — the quickstart runs with zero mounts
 COPY --from=build /dist/config /work/config
 
@@ -104,5 +104,5 @@ RUN useradd -r -u 10001 seed \
     && chown -R seed /work
 USER seed
 
-ENTRYPOINT ["cli"]
+ENTRYPOINT ["seedstream"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -152,10 +152,10 @@ java -jar seedstream-latest.jar execute --job config/jobs/file_address.yaml --co
 ### Option 2 — Distribution zip
 
 ```bash
-wget https://github.com/mferretti/SeedStream/releases/latest/download/cli-latest.zip
-unzip cli-latest.zip
+wget https://github.com/mferretti/SeedStream/releases/latest/download/seedstream-latest.zip
+unzip seedstream-latest.zip
 # Point to your own job configs or clone the repo for examples
-cli-*/bin/datagenerator execute --job /path/to/job.yaml --count 100
+seedstream-*/bin/seedstream execute --job /path/to/job.yaml --count 100
 ```
 
 ### Option 3 — Build from source
@@ -163,6 +163,14 @@ cli-*/bin/datagenerator execute --job /path/to/job.yaml --count 100
 ```bash
 git clone https://github.com/mferretti/SeedStream.git && cd SeedStream
 ./gradlew :cli:run --args="execute --job config/jobs/file_address.yaml --count 100"
+```
+
+Or use the `./seedstream` wrapper — it builds a runnable jar on first use, then runs
+directly with no Gradle and no `--args="…"` quoting (arguments pass straight through):
+
+```bash
+git clone https://github.com/mferretti/SeedStream.git && cd SeedStream
+./seedstream execute --job config/jobs/file_address.yaml --count 100
 ```
 
 ### Common examples
@@ -210,13 +218,13 @@ Already have a live database schema or an OpenAPI spec? `inspect` bootstraps See
 
 ```bash
 # From a SQL DDL file (auto-detected from .sql extension)
-datagenerator inspect schema.sql --output config/structures/
+./seedstream inspect schema.sql --output config/structures/
 
 # From an OpenAPI 3.x spec (auto-detected from .yaml / .json extension)
-datagenerator inspect api.yaml --output config/structures/
+./seedstream inspect api.yaml --output config/structures/
 
 # Overwrite any existing structure files
-datagenerator inspect schema.sql --output config/structures/ --force
+./seedstream inspect schema.sql --output config/structures/ --force
 ```
 
 **What you get**: one `{snake_case_name}.yaml` per `CREATE TABLE` or OpenAPI schema object, written to the output directory and immediately usable in a job. For example, given:
@@ -265,7 +273,7 @@ Fields with **no comment** were mapped from explicit schema information (declare
 **Opt-in nesting** (`--nest`): the DDL inspector can invert `1:n` / `1:1` foreign keys into embedded documents — the same `customer → invoice → invoice_item` chain then emits a `customer` that carries `invoices: array[object[invoice], 1..10]` and an `invoice` that carries `invoice_items: array[object[invoice_item], 1..10]`:
 
 ```bash
-datagenerator inspect schema.sql --nest --output config/structures/
+./seedstream inspect schema.sql --nest --output config/structures/
 # array multiplicity defaults to 1..10; override with --nest-default-count 2..5
 ```
 
@@ -291,7 +299,7 @@ datagenerator inspect schema.sql --nest --output config/structures/
 The built-in name hints cover common fields (`email`, `city`, `first_name`, etc.). For domain-specific column names, register extra Datafaker providers with `--faker-types`:
 
 ```bash
-datagenerator inspect schema.sql \
+./seedstream inspect schema.sql \
   --faker-types config/datafaker-types.example.yaml \
   --output config/structures/
 ```

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 
 application {
     mainClass.set("com.datagenerator.cli.DataGeneratorCli")
+    applicationName = "seedstream"
 }
 
 tasks.jar {

--- a/cli/src/main/java/com/datagenerator/cli/DataGeneratorCli.java
+++ b/cli/src/main/java/com/datagenerator/cli/DataGeneratorCli.java
@@ -36,7 +36,7 @@ import picocli.CommandLine.IVersionProvider;
  * </pre>
  */
 @Command(
-    name = "datagenerator",
+    name = "seedstream",
     mixinStandardHelpOptions = true,
     versionProvider = DataGeneratorCli.ManifestVersionProvider.class,
     description = "High-performance test data generator",

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -44,7 +44,7 @@ docker run --rm seedstream:local --help
 
 ## The `/work` layout
 
-`WORKDIR` is `/work`. The CLI is on `PATH` as `cli` and is the `ENTRYPOINT`, so
+`WORKDIR` is `/work`. The CLI is on `PATH` as `seedstream` and is the `ENTRYPOINT`, so
 a run reads as `docker run <image> execute --job ... --count ...`.
 
 ```

--- a/docs/DATAFAKER-COVERAGE.md
+++ b/docs/DATAFAKER-COVERAGE.md
@@ -117,7 +117,7 @@ types:
   pokemon:      pokemon.name             # faker.pokemon().name()
 ```
 ```bash
-datagenerator execute --job ... --faker-types my-types.yaml
+./seedstream execute --job ... --faker-types my-types.yaml
 ```
 
 The chain is resolved + validated at load (`DatafakerRegistry.registerExpression`), so a typo fails fast.
@@ -325,7 +325,7 @@ types:
   hospital: medical.hospitalName      # faker.medical().hospitalName()
 ```
 ```bash
-datagenerator execute --job ... --faker-types my-types.yaml
+./seedstream execute --job ... --faker-types my-types.yaml
 ```
 
 The chain is validated at load (`DatafakerRegistry.registerExpression`). This covers every no-arg

--- a/docs/INSPECT-V1-SPEC.md
+++ b/docs/INSPECT-V1-SPEC.md
@@ -1,4 +1,4 @@
-# datagenerator inspect — v1 Spec
+# seedstream inspect — v1 Spec
 
 Status: implemented. Scope: OpenAPI, SQL DDL **and** Protobuf → SeedStream structure YAML.
 Supersedes the open questions from the design phase with locked decisions.
@@ -18,9 +18,9 @@ Supersedes the open questions from the design phase with locked decisions.
   `.yaml`/`.yml`/`.json` → OpenAPI); `--format openapi|ddl|protobuf` overrides.
 
 ```bash
-datagenerator inspect api.yaml      --output config/structures/
-datagenerator inspect schema.sql    --output config/structures/ --force
-datagenerator inspect schema.desc   --output config/structures/   # protoc/buf descriptor set
+./seedstream inspect api.yaml      --output config/structures/
+./seedstream inspect schema.sql    --output config/structures/ --force
+./seedstream inspect schema.desc   --output config/structures/   # protoc/buf descriptor set
 ```
 
 Flags:
@@ -158,8 +158,8 @@ YAML parser ignores `#` comments, so annotated files round-trip cleanly.
     beerstyle:  beer_style
   ```
   ```bash
-  datagenerator inspect schema.sql --faker-types config/datafaker-types.example.yaml
-  datagenerator execute --job ...  --faker-types config/datafaker-types.example.yaml
+  ./seedstream inspect schema.sql --faker-types config/datafaker-types.example.yaml
+  ./seedstream execute --job ...  --faker-types config/datafaker-types.example.yaml
   ```
   - The chain is resolved + validated at load (`DatafakerRegistry.registerExpression`), so a typo
     fails fast.
@@ -231,7 +231,7 @@ its children as nested documents:
 | `--nest-default-count <min..max>` | array multiplicity when the schema gives no hint (default `1..10`) |
 
 ```bash
-datagenerator inspect schema.sql --nest --output config/structures/
+./seedstream inspect schema.sql --nest --output config/structures/
 ```
 
 - **1:1** (child FK column is `UNIQUE`/PK) → `object[child]`; **1:n** → `array[object[child], min..max]`.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -207,7 +207,7 @@ way until ~930 MB/s, where the writer thread becomes the next ceiling.
 
 ```bash
 ./gradlew :cli:installDist
-./cli/build/install/cli/bin/cli execute \
+./cli/build/install/seedstream/bin/seedstream execute \
     --job config/jobs/perf_probe_wide_file_json.yaml \
     --count 1000000 --threads $(nproc)
 ```

--- a/seedstream
+++ b/seedstream
@@ -1,0 +1,88 @@
+#!/bin/sh
+#
+# SeedStream launcher — the mvnw-style wrapper.
+#
+# Run the CLI without remembering `./gradlew :cli:run --args="…"` and its quoting,
+# and without hunting for a jar. Arguments pass straight through:
+#
+#   ./seedstream execute --job config/jobs/quickstart.yaml --count 1000
+#   ./seedstream inspect openapi api.yaml
+#   ./seedstream --help
+#
+# Resolution: use an existing self-contained fat JAR if present, otherwise build it
+# once via Gradle, then `java -jar`. Only *source* edits need a rebuild — config
+# files are read at runtime. Force a rebuild with SEEDSTREAM_REBUILD=1.
+#
+# Environment:
+#   JAVA_HOME          if set, $JAVA_HOME/bin/java is used; else `java` on PATH
+#   JAVA_OPTS          extra JVM flags (e.g. -Xmx4g)
+#   SEEDSTREAM_JAR     explicit path to a fat jar (skips discovery/build)
+#   SEEDSTREAM_REBUILD =1 forces `:cli:fatJar` before running
+#
+set -eu
+
+# --- resolve the directory this script lives in (follow symlinks) ------------
+PRG="$0"
+while [ -h "$PRG" ]; do
+  ls=$(ls -ld "$PRG")
+  link=$(expr "$ls" : '.*-> \(.*\)$')
+  case "$link" in
+    /*) PRG="$link" ;;
+    *)  PRG="$(dirname "$PRG")/$link" ;;
+  esac
+done
+SEEDSTREAM_HOME=$(cd "$(dirname "$PRG")" && pwd)
+
+# --- resolve java ------------------------------------------------------------
+if [ -n "${JAVA_HOME:-}" ]; then
+  JAVA="$JAVA_HOME/bin/java"
+else
+  JAVA="java"
+fi
+if ! command -v "$JAVA" >/dev/null 2>&1 && [ ! -x "$JAVA" ]; then
+  echo "seedstream: no Java found. Install Java 21+ or set JAVA_HOME." >&2
+  exit 1
+fi
+
+# Require Java 21+. `java -version` prints e.g. `openjdk version "21.0.2"` to stderr.
+JAVA_MAJOR=$("$JAVA" -version 2>&1 | head -n1 | sed -e 's/.*version "//' -e 's/".*//' -e 's/^1\.//' -e 's/[._-].*//')
+case "$JAVA_MAJOR" in
+  ''|*[!0-9]*)
+    echo "seedstream: could not determine Java version from '$JAVA'." >&2
+    exit 1 ;;
+  *)
+    if [ "$JAVA_MAJOR" -lt 21 ]; then
+      echo "seedstream: Java 21+ required, found major version $JAVA_MAJOR." >&2
+      exit 1
+    fi ;;
+esac
+
+# --- locate the fat jar (newest match wins) ----------------------------------
+find_jar() {
+  # $1 = glob pattern; echo the newest matching, readable file, if any.
+  # shellcheck disable=SC2012
+  ls -1t $1 2>/dev/null | head -n1
+}
+
+JAR=""
+if [ -n "${SEEDSTREAM_JAR:-}" ]; then
+  JAR="$SEEDSTREAM_JAR"
+elif [ "${SEEDSTREAM_REBUILD:-}" != "1" ]; then
+  JAR=$(find_jar "$SEEDSTREAM_HOME/seedstream-*.jar")
+  [ -n "$JAR" ] || JAR=$(find_jar "$SEEDSTREAM_HOME/cli/build/libs/seedstream-*.jar")
+fi
+
+# --- build on demand ---------------------------------------------------------
+if [ -z "$JAR" ] || [ ! -f "$JAR" ]; then
+  echo "seedstream: building the runtime jar (first run or SEEDSTREAM_REBUILD=1)…" >&2
+  "$SEEDSTREAM_HOME/gradlew" -p "$SEEDSTREAM_HOME" :cli:fatJar --console=plain -q
+  JAR=$(find_jar "$SEEDSTREAM_HOME/cli/build/libs/seedstream-*.jar")
+  if [ -z "$JAR" ] || [ ! -f "$JAR" ]; then
+    echo "seedstream: build did not produce cli/build/libs/seedstream-*.jar." >&2
+    exit 1
+  fi
+fi
+
+# --- run ---------------------------------------------------------------------
+# shellcheck disable=SC2086
+exec "$JAVA" ${JAVA_OPTS:-} -jar "$JAR" "$@"

--- a/seedstream.bat
+++ b/seedstream.bat
@@ -1,0 +1,62 @@
+@rem
+@rem SeedStream launcher for Windows — mirror of the POSIX `seedstream` wrapper.
+@rem
+@rem   seedstream execute --job config\jobs\quickstart.yaml --count 1000
+@rem   seedstream --help
+@rem
+@rem Uses an existing fat JAR if present, otherwise builds it once via Gradle,
+@rem then `java -jar`. Force a rebuild with SEEDSTREAM_REBUILD=1.
+@rem
+@rem   JAVA_HOME          if set, %JAVA_HOME%\bin\java is used; else `java` on PATH
+@rem   JAVA_OPTS          extra JVM flags
+@rem   SEEDSTREAM_JAR     explicit path to a fat jar (skips discovery/build)
+@rem   SEEDSTREAM_REBUILD =1 forces `:cli:fatJar` before running
+@rem
+@if "%DEBUG%"=="" @echo off
+setlocal
+
+set "SEEDSTREAM_HOME=%~dp0"
+
+@rem --- resolve java ----------------------------------------------------------
+if defined JAVA_HOME (
+  set "JAVA_EXE=%JAVA_HOME%\bin\java.exe"
+) else (
+  set "JAVA_EXE=java.exe"
+)
+
+@rem --- locate the fat jar ----------------------------------------------------
+set "JAR="
+if defined SEEDSTREAM_JAR (
+  set "JAR=%SEEDSTREAM_JAR%"
+) else if not "%SEEDSTREAM_REBUILD%"=="1" (
+  if exist "%SEEDSTREAM_HOME%seedstream-*.jar" (
+    for /f "delims=" %%f in ('dir /b /o-d "%SEEDSTREAM_HOME%seedstream-*.jar"') do (
+      set "JAR=%SEEDSTREAM_HOME%%%f" & goto :haveJar
+    )
+  )
+  if exist "%SEEDSTREAM_HOME%cli\build\libs\seedstream-*.jar" (
+    for /f "delims=" %%f in ('dir /b /o-d "%SEEDSTREAM_HOME%cli\build\libs\seedstream-*.jar"') do (
+      set "JAR=%SEEDSTREAM_HOME%cli\build\libs\%%f" & goto :haveJar
+    )
+  )
+)
+:haveJar
+
+@rem --- build on demand -------------------------------------------------------
+if not defined JAR goto :build
+if not exist "%JAR%" goto :build
+goto :run
+
+:build
+echo seedstream: building the runtime jar ^(first run or SEEDSTREAM_REBUILD=1^)...  1>&2
+call "%SEEDSTREAM_HOME%gradlew.bat" -p "%SEEDSTREAM_HOME%" :cli:fatJar --console=plain -q
+if errorlevel 1 exit /b 1
+for /f "delims=" %%f in ('dir /b /o-d "%SEEDSTREAM_HOME%cli\build\libs\seedstream-*.jar"') do (
+  set "JAR=%SEEDSTREAM_HOME%cli\build\libs\%%f" & goto :run
+)
+echo seedstream: build did not produce cli\build\libs\seedstream-*.jar. 1>&2
+exit /b 1
+
+:run
+"%JAVA_EXE%" %JAVA_OPTS% -jar "%JAR%" %*
+exit /b %ERRORLEVEL%

--- a/use-cases/dora-gdpr-sepa-payments/README.md
+++ b/use-cases/dora-gdpr-sepa-payments/README.md
@@ -80,7 +80,7 @@ path and the auto-resolved `structures/` directory are relative to the job file)
 
 ```bash
 ./gradlew :cli:installDist
-./cli/build/install/cli/bin/cli execute \
+./cli/build/install/seedstream/bin/seedstream execute \
   --job use-cases/dora-gdpr-sepa-payments/jobs/file_sepa_credit_transfer.yaml \
   --faker-types use-cases/dora-gdpr-sepa-payments/faker-types.yaml --count 20
 # → build/run-output/sepa_credit_transfers.json  (one JSON object per line)


### PR DESCRIPTION
## Summary

Adds an `mvnw`-style wrapper so users run the CLI without `./gradlew :cli:run --args="..."` quoting or hunting for a jar.

- **`seedstream` + `seedstream.bat`** — prefer an existing self-contained fat JAR; if none, build one via `:cli:fatJar` on first run, then `exec java -jar` with arguments passed straight through. Guards for Java 21+; honors `JAVA_OPTS`, `SEEDSTREAM_JAR`, `SEEDSTREAM_REBUILD`.

  ```bash
  ./seedstream execute --job config/jobs/quickstart.yaml --count 1000
  ```

- **Rename Gradle launcher `cli` → `seedstream`** (`applicationName`) so the dist zip, Docker `ENTRYPOINT`, and `--help` usage name all match the wrapper. picocli `@Command(name)` updated too.

- **Doc dangling fixes** left by the rename: distribution zip name + `bin/` path in README, `install/cli/bin/cli` paths in `docs/PERFORMANCE.md` and the SEPA use-case, the `PATH` launcher name in `docs/CONTAINER.md`, and the release-workflow asset names. Replaced the never-existent `datagenerator <cmd>` invocations across README, `INSPECT-V1-SPEC` and `DATAFAKER-COVERAGE` with `./seedstream <cmd>`. Soft `./gradlew :cli:run --args=` references left as-is (still valid).

## Verification

- `./gradlew clean build` — green (spotless, spotbugs, unit + IT).
- Determinism regression (`GenerationEngineTest`, `ExecuteCommandTest`) re-run with `--rerun-tasks` — green.
- Wrapper end-to-end: first run bootstraps the jar and `--help` shows usage name `seedstream`; second run skips the build and generates `out/invoices.json`; missing Java gives a clear error and non-zero exit.
- Local SonarQube quality gate **OK**, 0 blocker/critical.