### PR TITLE
fix(docs): finish ./seedstream rename in scripts, benchmarks, and samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,12 +470,12 @@ To report a vulnerability, open a [GitHub issue](https://github.com/mferretti/Se
 
 ---
 
-## Example: `support_ticket` Domain
+## Built-in sample: `support_ticket`
 
-A ready-to-run example of a new domain. Structure: `config/structures/support_ticket.yaml` (uses primitives, `enum[...]`, `date[...]`, and a nested `object[...]`). Job: `config/jobs/file_support_ticket.yaml` (writes JSON to a file).
+A ready-to-run sample structure shipped in `config/`. Structure: `config/structures/support_ticket.yaml` (uses primitives, `enum[...]`, `date[...]`, and a nested `object[...]`). Job: `config/jobs/file_support_ticket.yaml` (writes JSON to a file).
 
 ```bash
-./gradlew :cli:run --args="execute --job config/jobs/file_support_ticket.yaml --count 20"
+./seedstream execute --job config/jobs/file_support_ticket.yaml --count 20
 ```
 
 Re-running with the same `--seed` produces byte-for-byte identical output.

--- a/benchmarks/run_e2e_test.sh
+++ b/benchmarks/run_e2e_test.sh
@@ -58,7 +58,7 @@ RESULTS_FILE="${PROJECT_ROOT}/benchmarks/e2e_results.csv"
 GC_LOG_DIR="${PROJECT_ROOT}/benchmarks/build/gc_logs"
 JFR_OUTPUT_DIR="${PROJECT_ROOT}/benchmarks/build/jfr"
 OUTPUT_DIR="${PROJECT_ROOT}/build/run-output"
-CLI_SCRIPT="${PROJECT_ROOT}/cli/build/install/cli/bin/cli"
+CLI_SCRIPT="${PROJECT_ROOT}/cli/build/install/seedstream/bin/seedstream"
 
 # Test matrix
 FORMATS=("json" "csv" "protobuf")
@@ -219,7 +219,7 @@ build_project() {
     # installDist wipes extras/ on every sync, so (re)install the PostgreSQL JDBC
     # driver the database tests need. Driver is NOT bundled by design; pull the
     # release jar from the Gradle cache if present.
-    local extras_dir="${PROJECT_ROOT}/cli/build/install/cli/extras"
+    local extras_dir="${PROJECT_ROOT}/cli/build/install/seedstream/extras"
     mkdir -p "$extras_dir"
     if ! ls "$extras_dir"/postgresql-*.jar >/dev/null 2>&1; then
         local pg_jar

--- a/benchmarks/run_regex_e2e.sh
+++ b/benchmarks/run_regex_e2e.sh
@@ -42,7 +42,7 @@ RESULTS_FILE="${PROJECT_ROOT}/benchmarks/regex_e2e_results.csv"
 REPORT_FILE="${PROJECT_ROOT}/docs/REGEX-E2E-RESULTS.md"
 GC_LOG_DIR="${PROJECT_ROOT}/benchmarks/build/gc_logs_regex"
 OUTPUT_DIR="${PROJECT_ROOT}/build/run-output"
-CLI_SCRIPT="${PROJECT_ROOT}/cli/build/install/cli/bin/cli"
+CLI_SCRIPT="${PROJECT_ROOT}/cli/build/install/seedstream/bin/seedstream"
 FAKER_TYPES="${PROJECT_ROOT}/config/datafaker-types.regex-bench.yaml"
 
 # Test matrix — same thread/heap grid as run_e2e_test.sh so the numbers sit alongside it

--- a/config/datafaker-types.example.yaml
+++ b/config/datafaker-types.example.yaml
@@ -4,8 +4,8 @@
 # a Datafaker method path (each dot-separated segment is a no-arg method, invoked left to right
 # starting on the Faker instance). The chain is validated at load time, so a typo fails fast.
 #
-# Use with:  datagenerator inspect schema.sql --faker-types config/datafaker-types.example.yaml
-#       and: datagenerator execute --job ... --faker-types config/datafaker-types.example.yaml
+# Use with:  ./seedstream inspect schema.sql --faker-types config/datafaker-types.example.yaml
+#       and: ./seedstream execute --job ... --faker-types config/datafaker-types.example.yaml
 #
 # Once registered, a structure can reference the key directly, e.g.  datatype: beer_style
 # The inspector also auto-targets a custom type when a column name matches its key.

--- a/config/datafaker-types.regex-bench.yaml
+++ b/config/datafaker-types.regex-bench.yaml
@@ -4,7 +4,7 @@
 # the same shapes through the full generate → serialize → write pipeline so the micro numbers can be
 # checked against a real throughput figure.
 #
-# Use with:  cli execute --job config/jobs/e2e_regex_file_json.yaml \
+# Use with:  ./seedstream execute --job config/jobs/e2e_regex_file_json.yaml \
 #              --faker-types config/datafaker-types.regex-bench.yaml
 
 types:

--- a/scripts/determinism-demo.sh
+++ b/scripts/determinism-demo.sh
@@ -24,7 +24,7 @@ trap cleanup EXIT
 
 echo "==> Building CLI (one time)…"
 ./gradlew -q :cli:installDist
-CLI="$ROOT/cli/build/install/cli/bin/cli"
+CLI="$ROOT/cli/build/install/seedstream/bin/seedstream"
 
 run_hash() {
   local threads="$1"

--- a/scripts/profile-memory.sh
+++ b/scripts/profile-memory.sh
@@ -45,7 +45,7 @@ echo "Starting data generation with JFR profiling..."
 echo ""
 
 # Build CLI distribution if needed
-if [ ! -f "cli/build/install/cli/bin/cli" ]; then
+if [ ! -f "cli/build/install/seedstream/bin/seedstream" ]; then
     echo "Building CLI distribution..."
     ./gradlew :cli:installDist
     echo ""
@@ -57,7 +57,7 @@ if [[ ! "$JOB_FILE" = /* ]]; then
 fi
 
 # Run the CLI with JFR enabled
-JAVA_OPTS="$JVM_OPTS $JFR_SETTINGS" cli/build/install/cli/bin/cli execute --job "$JOB_FILE" --count $RECORD_COUNT --threads $THREADS
+JAVA_OPTS="$JVM_OPTS $JFR_SETTINGS" cli/build/install/seedstream/bin/seedstream execute --job "$JOB_FILE" --count $RECORD_COUNT --threads $THREADS
 
 echo ""
 echo "=== Profiling Complete ==="

--- a/use-cases/dora-gdpr-sepa-payments/faker-types.yaml
+++ b/use-cases/dora-gdpr-sepa-payments/faker-types.yaml
@@ -4,7 +4,7 @@
 # of plain random alphanumeric. Pass this file to the CLI so the structure's `sepa_*` datatypes
 # resolve:
 #
-#   ./cli/build/install/cli/bin/cli execute \
+#   ./seedstream execute \
 #     --job use-cases/dora-gdpr-sepa-payments/jobs/file_sepa_credit_transfer.yaml \
 #     --faker-types use-cases/dora-gdpr-sepa-payments/faker-types.yaml --count 20
 #


### PR DESCRIPTION
## What

The `./seedstream` launcher rename (landed as `9b941c3`) was squash-merged, but a handful of follow-up reference fixes never made it onto `main`. This finishes the rename in the files the squash missed.

## Changes (docs/scripts/config only — no code)

- **Benchmarks/scripts**: `cli/build/install/cli/bin/cli` → `cli/build/install/seedstream/bin/seedstream` in `benchmarks/run_e2e_test.sh`, `benchmarks/run_regex_e2e.sh`, `scripts/determinism-demo.sh`, `scripts/profile-memory.sh` (the path `installDist` now actually produces).
- **Sample headers**: `datagenerator`/`cli` → `./seedstream` in `config/datafaker-types.example.yaml`, `config/datafaker-types.regex-bench.yaml`, and `use-cases/dora-gdpr-sepa-payments/faker-types.yaml`.
- **README**: `./gradlew :cli:run --args=…` → `./seedstream …` and the `support_ticket` heading reworded to "Built-in sample".

## Verification

- `./gradlew :cli:installDist` produces `cli/build/install/seedstream/bin/seedstream` (executable) — the path the scripts now reference.
- Repo-wide `grep` confirms no remaining `install/cli/bin/cli` or `datagenerator <cmd>` references.
- Local unit tests + JaCoCo + SonarQube gate: **PASS** (coverage 85.3%, new-code 90.3%).