### PR TITLE
feat(inspect): support standalone JSON Schema as input (#89)

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -9,8 +9,9 @@ dependencies {
     implementation(project(":formats"))
     implementation(project(":destinations"))
     implementation(project(":inspector"))
-    // Jackson for JSON processing
+    // Jackson for JSON processing (YAML for inspect format auto-detection peek)
     implementation(libs.jackson.databind)
+    implementation(libs.jackson.dataformat.yaml)
     // CLI framework
     implementation(libs.picocli)
     // Logback for programmatic log level control

--- a/cli/src/main/java/com/datagenerator/cli/InspectCommand.java
+++ b/cli/src/main/java/com/datagenerator/cli/InspectCommand.java
@@ -16,16 +16,22 @@
 
 package com.datagenerator.cli;
 
+import com.datagenerator.inspector.FakerTypeSuggestionsWriter;
 import com.datagenerator.inspector.Inspection;
 import com.datagenerator.inspector.InspectorException;
 import com.datagenerator.inspector.StructureYamlWriter;
 import com.datagenerator.inspector.ddl.DdlInspector;
 import com.datagenerator.inspector.ddl.NestingOptions;
+import com.datagenerator.inspector.jsonschema.JsonSchemaInspector;
 import com.datagenerator.inspector.openapi.OpenApiInspector;
 import com.datagenerator.inspector.protobuf.ProtobufInspector;
 import com.datagenerator.schema.exception.SchemaParseException;
 import com.datagenerator.schema.model.DataStructure;
 import com.datagenerator.schema.parser.CustomTypeConfigLoader;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Map;
@@ -38,16 +44,18 @@ import picocli.CommandLine.Parameters;
 /**
  * Reads an existing schema and emits ready-to-use SeedStream structure YAML files.
  *
- * <p>Supports OpenAPI 3.x specs (JSON/YAML) and SQL DDL ({@code .sql}). Format is auto-detected
- * from the file extension and can be overridden with {@code --format}. See {@code
- * docs/INSPECT-V1-SPEC.md}.
+ * <p>Supports OpenAPI 3.x specs (JSON/YAML), standalone JSON Schema ({@code .schema.json} or a
+ * {@code $schema}/{@code $defs} root), SQL DDL ({@code .sql}), and compiled Protobuf descriptor
+ * sets. Format is auto-detected from the file extension/content and can be overridden with {@code
+ * --format}. See {@code docs/INSPECT-V1-SPEC.md}.
  *
  * <p><b>Usage:</b>
  *
  * <pre>
  * datagenerator inspect api.yaml --output config/structures/
+ * datagenerator inspect payload.schema.json --output config/structures/
  * datagenerator inspect schema.sql --output config/structures/ --force
- * datagenerator inspect spec.yaml --format ddl
+ * datagenerator inspect spec.yaml --format jsonschema
  * </pre>
  *
  * <p><b>Exit codes:</b>
@@ -60,16 +68,20 @@ import picocli.CommandLine.Parameters;
 @Slf4j
 @Command(
     name = "inspect",
-    description = "Generate SeedStream structure YAML from an OpenAPI spec or SQL DDL",
+    description =
+        "Generate SeedStream structure YAML from an OpenAPI spec, JSON Schema, SQL DDL, or Protobuf",
     mixinStandardHelpOptions = true)
 public class InspectCommand implements Callable<Integer> {
   private static final String FORMAT_PROTOBUF = "protobuf";
+  private static final String FORMAT_OPENAPI = "openapi";
+  private static final String FORMAT_JSONSCHEMA = "jsonschema";
 
   @Parameters(
       index = "0",
       description =
-          "Schema file to inspect: OpenAPI 3.x (.yaml/.yml/.json), SQL DDL (.sql), or compiled"
-              + " Protobuf descriptor set (.desc/.binpb/.protoset)")
+          "Schema file to inspect: OpenAPI 3.x (.yaml/.yml/.json), standalone JSON Schema"
+              + " (.schema.json or a $schema/$defs root), SQL DDL (.sql), or compiled Protobuf"
+              + " descriptor set (.desc/.binpb/.protoset)")
   private Path inputFile;
 
   @Option(
@@ -84,7 +96,9 @@ public class InspectCommand implements Callable<Integer> {
 
   @Option(
       names = {"--format"},
-      description = "Input format: openapi | ddl. Default: auto-detect from file extension.")
+      description =
+          "Input format: openapi | jsonschema | ddl | protobuf. Default: auto-detect from file"
+              + " extension/content.")
   private String format = "auto";
 
   @Option(
@@ -131,7 +145,8 @@ public class InspectCommand implements Callable<Integer> {
     }
     if (nest != null && !"ddl".equals(resolved)) {
       log.warn(
-          "--nest ignored for OpenAPI input (nesting comes from the spec's native $ref/array)");
+          "--nest ignored for {} input (nesting comes from the schema's native $ref/array)",
+          resolved);
     }
 
     try {
@@ -140,6 +155,8 @@ public class InspectCommand implements Callable<Integer> {
         inspection = new DdlInspector().inspect(inputFile, resolveNesting(resolved), bestEffort);
       } else if (FORMAT_PROTOBUF.equals(resolved)) {
         inspection = new ProtobufInspector().inspect(inputFile);
+      } else if (FORMAT_JSONSCHEMA.equals(resolved)) {
+        inspection = new JsonSchemaInspector().inspect(inputFile);
       } else {
         inspection = new OpenApiInspector().inspect(inputFile);
       }
@@ -163,6 +180,7 @@ public class InspectCommand implements Callable<Integer> {
       }
 
       inspection.warnings().forEach(log::warn);
+      writeFakerTypeSuggestions(inspection.fakerTypeSuggestions());
 
       log.info(
           "inspect complete: {} written, {} skipped, {} fields flagged for review (commented)",
@@ -173,6 +191,37 @@ public class InspectCommand implements Callable<Integer> {
     } catch (InspectorException e) {
       log.error("inspect failed: {}", e.getMessage());
       return 2;
+    }
+  }
+
+  /**
+   * Writes discovered regex/custom-type suggestions to a companion {@code
+   * inspect-faker-types.yaml}, never clobbering an existing file or the {@code --faker-types}
+   * input. On a skip the suggestions are logged so the user can still act on them.
+   */
+  private void writeFakerTypeSuggestions(Map<String, String> suggestions) {
+    FakerTypeSuggestionsWriter.Outcome outcome =
+        new FakerTypeSuggestionsWriter().write(suggestions, outputDir, force, fakerTypes);
+    switch (outcome.result()) {
+      case WRITTEN ->
+          log.info(
+              "wrote {} ({} suggested type(s)) — rerun with --faker-types {} to apply",
+              outcome.target(),
+              suggestions.size(),
+              outcome.target());
+      case SKIPPED_EXISTS ->
+          log.warn(
+              "{} exists — not overwritten (use --force). Suggested types: {}",
+              outcome.target(),
+              suggestions);
+      case SKIPPED_IS_INPUT ->
+          log.warn(
+              "not writing suggestions over the --faker-types input {}. Suggested types: {}",
+              outcome.target(),
+              suggestions);
+      default -> {
+        // NONE (or any future outcome): nothing to write
+      }
     }
   }
 
@@ -202,10 +251,11 @@ public class InspectCommand implements Callable<Integer> {
   private String resolveFormat() {
     String requested = format.toLowerCase(Locale.ROOT);
     return switch (requested) {
-      case "openapi", "ddl", FORMAT_PROTOBUF -> requested;
+      case FORMAT_OPENAPI, "ddl", FORMAT_PROTOBUF, FORMAT_JSONSCHEMA -> requested;
       case "auto" -> detectFormat();
       default -> {
-        log.error("Unsupported --format '{}'. Supported: openapi, ddl, protobuf", format);
+        log.error(
+            "Unsupported --format '{}'. Supported: openapi, jsonschema, ddl, protobuf", format);
         yield null;
       }
     };
@@ -222,12 +272,44 @@ public class InspectCommand implements Callable<Integer> {
         || fileName.endsWith(".protoset")) {
       return FORMAT_PROTOBUF;
     }
+    if (fileName.endsWith(".schema.json")) {
+      return FORMAT_JSONSCHEMA;
+    }
     if (fileName.endsWith(".yaml") || fileName.endsWith(".yml") || fileName.endsWith(".json")) {
-      return "openapi";
+      // .json/.yaml is ambiguous between OpenAPI and standalone JSON Schema — peek the root.
+      return peekJsonOrYamlFormat();
     }
     log.error(
-        "Cannot auto-detect format for '{}'. Use --format openapi|ddl|protobuf",
+        "Cannot auto-detect format for '{}'. Use --format openapi|jsonschema|ddl|protobuf",
         inputFile.getFileName());
     return null;
+  }
+
+  /**
+   * Disambiguates a {@code .json}/{@code .yaml} input by its root keys: an OpenAPI document has
+   * {@code openapi}/{@code swagger}; a standalone JSON Schema has {@code $schema}/{@code
+   * $defs}/{@code definitions}. Defaults to OpenAPI (the historical behaviour) when neither is
+   * present or the file cannot be parsed, so detection never hard-fails here.
+   */
+  private String peekJsonOrYamlFormat() {
+    try {
+      ObjectMapper reader =
+          inputFile.toString().toLowerCase(Locale.ROOT).endsWith(".json")
+              ? new ObjectMapper()
+              : new YAMLMapper();
+      JsonNode root = reader.readTree(inputFile.toFile());
+      if (root == null || !root.isObject()) {
+        return FORMAT_OPENAPI;
+      }
+      if (root.has(FORMAT_OPENAPI) || root.has("swagger")) {
+        return FORMAT_OPENAPI;
+      }
+      if (root.has("$schema") || root.has("$defs") || root.has("definitions")) {
+        return FORMAT_JSONSCHEMA;
+      }
+    } catch (IOException e) {
+      log.debug("format peek failed for {}, defaulting to openapi: {}", inputFile, e.getMessage());
+    }
+    return FORMAT_OPENAPI;
   }
 }

--- a/cli/src/test/java/com/datagenerator/cli/InspectCommandTest.java
+++ b/cli/src/test/java/com/datagenerator/cli/InspectCommandTest.java
@@ -70,6 +70,22 @@ class InspectCommandTest {
               id: {type: string, format: uuid}
       """;
 
+  // JSON kept as a concatenated string: google-java-format mangles a text block starting with '{'.
+  private static final String JSON_SCHEMA =
+      "{ \"title\": \"Widget\", \"type\": \"object\","
+          + " \"properties\": {"
+          + "   \"code\": { \"type\": \"string\", \"pattern\": \"^[A-Z]{3}$\" },"
+          + "   \"name\": { \"type\": \"string\" } } }";
+
+  private static final String YAML_SCHEMA =
+      """
+      $schema: "https://json-schema.org/draft/2020-12/schema"
+      title: Gadget
+      type: object
+      properties:
+        id: {type: string, format: uuid}
+      """;
+
   private int run(String... args) {
     return new CommandLine(new InspectCommand()).execute(args);
   }
@@ -160,6 +176,120 @@ class InspectCommandTest {
   void nestIgnoredForOpenApiButStillSucceeds() throws Exception {
     Path spec = write("api.yaml", MINIMAL_OPENAPI);
     assertThat(run(spec.toString(), "-o", outDir().toString(), "--nest")).isZero();
+    assertThat(outDir().resolve("thing.yaml")).exists();
+  }
+
+  @Test
+  void jsonSchemaByExtensionAutoDetectedAndWritesFakerTypes() throws Exception {
+    Path schema = write("payload.schema.json", JSON_SCHEMA);
+    assertThat(run(schema.toString(), "-o", outDir().toString())).isZero();
+    assertThat(outDir().resolve("widget.yaml")).exists();
+    // the regex `pattern` field emits a companion faker-types file the user can feed back
+    assertThat(outDir().resolve("inspect-faker-types.yaml")).exists();
+  }
+
+  @Test
+  void jsonSchemaOnYamlDetectedByContentPeek() throws Exception {
+    // .yaml is ambiguous — the $schema root key disambiguates it as JSON Schema, not OpenAPI.
+    Path schema = write("schema.yaml", YAML_SCHEMA);
+    assertThat(run(schema.toString(), "-o", outDir().toString())).isZero();
+    assertThat(outDir().resolve("gadget.yaml")).exists();
+  }
+
+  @Test
+  void jsonSchemaExplicitFormatOverride() throws Exception {
+    Path schema =
+        write(
+            "plain.json",
+            "{ \"type\": \"object\", \"properties\": { \"x\": { \"type\": \"string\" } } }");
+    assertThat(run(schema.toString(), "-o", outDir().toString(), "--format", "jsonschema"))
+        .isZero();
+    assertThat(outDir().resolve("plain.yaml")).exists();
+  }
+
+  @Test
+  void nestIgnoredForJsonSchemaButStillSucceeds() throws Exception {
+    Path schema = write("payload.schema.json", JSON_SCHEMA);
+    assertThat(run(schema.toString(), "-o", outDir().toString(), "--nest")).isZero();
+    assertThat(outDir().resolve("widget.yaml")).exists();
+  }
+
+  @Test
+  void companionFakerTypesNotClobberedOnRerun() throws Exception {
+    Path schema = write("payload.schema.json", JSON_SCHEMA);
+    assertThat(run(schema.toString(), "-o", outDir().toString())).isZero();
+    Path companion = outDir().resolve("inspect-faker-types.yaml");
+    String firstContent = Files.readString(companion);
+
+    // rerun without --force: the companion exists → skipped, left byte-for-byte intact.
+    assertThat(run(schema.toString(), "-o", outDir().toString())).isZero();
+    assertThat(Files.readString(companion)).isEqualTo(firstContent);
+  }
+
+  @Test
+  void companionNotWrittenOverFakerTypesInput() throws Exception {
+    Path schema = write("payload.schema.json", JSON_SCHEMA);
+    assertThat(run(schema.toString(), "-o", outDir().toString())).isZero();
+    Path companion = outDir().resolve("inspect-faker-types.yaml");
+    String before = Files.readString(companion);
+
+    // point --faker-types at the companion itself: must refuse to overwrite its own input,
+    // even with --force.
+    assertThat(
+            run(
+                schema.toString(),
+                "-o",
+                outDir().toString(),
+                "--force",
+                "--faker-types",
+                companion.toString()))
+        .isZero();
+    assertThat(Files.readString(companion)).isEqualTo(before);
+  }
+
+  @Test
+  void invalidFormatOverrideReturnsTwo() throws Exception {
+    Path schema = write("payload.schema.json", JSON_SCHEMA);
+    assertThat(run(schema.toString(), "-o", outDir().toString(), "--format", "bogus")).isEqualTo(2);
+  }
+
+  @Test
+  void unknownExtensionCannotAutoDetectReturnsTwo() throws Exception {
+    Path file = write("schema.txt", JSON_SCHEMA);
+    assertThat(run(file.toString(), "-o", outDir().toString())).isEqualTo(2);
+  }
+
+  @Test
+  void nonObjectJsonRootPeeksAsOpenApiThenFails() throws Exception {
+    // A JSON array root is neither OpenAPI nor JSON Schema → peek defaults to OpenAPI, which then
+    // fails (no components.schemas) with exit 2.
+    Path file = write("array.json", "[1, 2, 3]");
+    assertThat(run(file.toString(), "-o", outDir().toString())).isEqualTo(2);
+  }
+
+  @Test
+  void malformedJsonPeekFallsBackToOpenApiThenFails() throws Exception {
+    // Unparseable content → the peek swallows the IOException and defaults to OpenAPI, which then
+    // fails to read it; detection itself never hard-crashes.
+    Path file = write("broken.json", "{ not valid json ");
+    assertThat(run(file.toString(), "-o", outDir().toString())).isEqualTo(2);
+  }
+
+  @Test
+  void yamlWithoutMarkersFallsBackToOpenApi() throws Exception {
+    // No openapi/swagger key and no $schema/$defs/definitions → content-peek defaults to OpenAPI.
+    Path spec =
+        write(
+            "spec.yaml",
+            """
+            components:
+              schemas:
+                Thing:
+                  type: object
+                  properties:
+                    id: {type: string}
+            """);
+    assertThat(run(spec.toString(), "-o", outDir().toString())).isZero();
     assertThat(outDir().resolve("thing.yaml")).exists();
   }
 }

--- a/docs/INSPECT-V1-SPEC.md
+++ b/docs/INSPECT-V1-SPEC.md
@@ -1,11 +1,13 @@
 # seedstream inspect — v1 Spec
 
-Status: implemented. Scope: OpenAPI, SQL DDL **and** Protobuf → SeedStream structure YAML.
-Supersedes the open questions from the design phase with locked decisions.
+Status: implemented. Scope: OpenAPI, standalone JSON Schema, SQL DDL **and** Protobuf → SeedStream
+structure YAML. Supersedes the open questions from the design phase with locked decisions.
 
 ## 1. Scope
 
 - **In**: OpenAPI 3.x specs (`.yaml` / `.json`, object schemas under `components.schemas`),
+  standalone **JSON Schema** (Draft 7 / 2020-12 — root object schema + entries under
+  `$defs`/`definitions`; see §10),
   SQL DDL (`.sql`, `CREATE TABLE` statements incl. foreign keys → `ref[...]`), and compiled
   Protobuf **FileDescriptorSet**s (`.desc` / `.binpb` / `.protoset` from `protoc --descriptor_set_out`
   or `buf build -o`; one structure per message, nested messages → `object[...]`, `repeated` → `array[...]`,
@@ -14,13 +16,16 @@ Supersedes the open questions from the design phase with locked decisions.
   Parsing `.proto` source directly is not supported — pre-compile to a descriptor set.
 - **Out**: `alias` emission, nullable/required hints, geolocation/locale, primary-key handling.
 - One `inspect` subcommand on the existing `datagenerator` CLI. No separate binary.
-- Format auto-detected from extension (`.sql` → DDL, `.desc`/`.binpb`/`.protoset` → Protobuf,
-  `.yaml`/`.yml`/`.json` → OpenAPI); `--format openapi|ddl|protobuf` overrides.
+- Format auto-detected from extension/content (`.sql` → DDL, `.desc`/`.binpb`/`.protoset` →
+  Protobuf, `.schema.json` → JSON Schema; for plain `.yaml`/`.yml`/`.json` the root keys
+  disambiguate — `openapi`/`swagger` → OpenAPI, else `$schema`/`$defs`/`definitions` → JSON Schema,
+  else OpenAPI); `--format openapi|jsonschema|ddl|protobuf` overrides.
 
 ```bash
-./seedstream inspect api.yaml      --output config/structures/
-./seedstream inspect schema.sql    --output config/structures/ --force
-./seedstream inspect schema.desc   --output config/structures/   # protoc/buf descriptor set
+./seedstream inspect api.yaml            --output config/structures/
+./seedstream inspect payload.schema.json --output config/structures/   # standalone JSON Schema
+./seedstream inspect schema.sql          --output config/structures/ --force
+./seedstream inspect schema.desc         --output config/structures/   # protoc/buf descriptor set
 ```
 
 Flags:
@@ -28,7 +33,7 @@ Flags:
 |---|---|---|
 | `--output <dir>` | `config/structures/` | where YAML files are written |
 | `--force` | off | overwrite existing files (else skip + warn — never silent clobber) |
-| `--format openapi\|ddl\|protobuf` | auto | input format override; supports all three implemented inspectors |
+| `--format openapi\|jsonschema\|ddl\|protobuf` | auto | input format override; supports all four implemented inspectors |
 | `--faker-types <file>` | unset | optional custom Datafaker types config loaded before inspection |
 | `--best-effort` | off | DDL only: emit the parseable subset and warn on unparseable `CREATE TABLE`s instead of aborting |
 | `--nest[=auto\|all\|none]` | `none` | DDL only: invert `1:n`/`1:1` FKs into nested `array[object[child]]`/`object[child]` — see §9 |
@@ -286,3 +291,67 @@ All warnings flow through the existing `Inspection.warnings` channel and the CLI
 
 **Implementation:** `NestingOptions`, `NestingPlanner`, `Pluralizer`; entry point
 `DdlInspector.inspect(Path, NestingOptions)`.
+
+## 10. JSON Schema specifics
+
+Standalone JSON Schema (Draft 7 / 2020-12) is mapped by the same `SchemaTypeMapper` the OpenAPI
+inspector uses — the per-property vocabulary (`type`, `format`, `enum`, `minimum`/`maximum`,
+`maxLength`, `minItems`/`maxItems`, `$ref`, `items`) is identical (see §3). Only the **entry point**
+differs.
+
+**Entry points → structures:**
+- The **root** object schema (any schema with `properties`) → one structure. Its name is taken from
+  `title` → `$id` (last path segment) → the file-name stem, then run through the same safe-name
+  guard as the emitted YAML file (`Names.requireSafeStructureName`).
+- Every entry under **`$defs`** and **`definitions`** (both supported) → one structure each, named
+  `snake_case(key)`.
+- Local `$ref` (`#/$defs/Foo`, `#/definitions/Foo`) → `object[foo]`, resolved by last path segment.
+- No root object schema and no `$defs`/`definitions` → error (`not a recognizable JSON Schema`).
+
+### Composition & conditionals — merged, because we generate data
+
+`inspect` produces **data**, not a validator, so it emits every field that could appear rather than
+dropping constructs it can't fully honour. At the **structure level** (keywords sitting beside
+`properties`) the subschemas of `allOf` / `oneOf` / `anyOf` / `if` / `then` / `else` /
+`dependentSchemas` — and any local `$ref` among them — are **merged into one record** (union,
+first-declared field wins). Local `$ref`s are resolved against `$defs`/`definitions`.
+
+- **`allOf`** is an exact merge (the "extends" idiom) — no comment, no warning.
+- The **lossy** branches (`oneOf`/`anyOf`/`if`/`then`/`else`/`dependentSchemas`) still get merged so
+  their fields are emitted, but the conditional/polymorphic relationship is dropped. Each such field
+  gets an inline `# review:` comment, and the structure gets a warning: the union record **may not
+  validate** against the source (mutually-exclusive variants co-populated, one branch's bounds
+  chosen on conflict). `not` / `patternProperties` / `additionalProperties: true` /
+  `dependentRequired` add nothing mergeable but still warn.
+
+Example — a root `if`/`then`/`else` that tightens `membershipNumber` per branch: both `isMember` and
+`membershipNumber` are emitted and flagged, with a structure warning that the conditional isn't
+enforced.
+
+*Per-property* composition (the same keywords on a single field, which occupies one datatype slot and
+so **can't** be unioned) is still flagged with a `# review:` comment + placeholder `char[1..50]`:
+`oneOf`/`anyOf`/`allOf`, `if`/`then`/`else`, `const`, `not`, tuple-form `items`, `patternProperties`,
+`additionalProperties: true`, external `$ref`, recursive `$ref`.
+
+### Regex (`pattern`) → suggested faker-type + rerun
+
+SeedStream has no inline regex datatype; regex generation is a **custom Datafaker type** registered
+via `--faker-types` (`name: "regex:<pattern>"` → `DatafakerRegistry.registerRegex`). So on a
+`string` + `pattern` field, `inspect`:
+
+1. maps the field to `char[1..N]` and adds a `# review:` comment naming the pattern,
+2. accumulates the pattern into a companion **`inspect-faker-types.yaml`** in the output dir, keyed
+   by the (snake_case) field name,
+3. on rerun with `--faker-types inspect-faker-types.yaml`, the field resolves by name-hint to the
+   registered regex generator (datatype becomes the type name), producing matching values.
+
+The companion file **never clobbers**: an existing file is left untouched unless `--force`, and the
+target is refused outright if it is the very `--faker-types` input the run was given (the suggestions
+are logged instead, so nothing is lost).
+
+**Positioning.** `inspect` is a **bootstrap + sync** for large / nested / constraint-rich schemas.
+For a small flat structure (≤ ~10 primitive fields), hand-writing the YAML stays the blessed path —
+the inspect → review → fix loop costs more than just typing it.
+
+**Implementation:** `JsonSchemaInspector`, `JsonSchemaGaps`, `FakerTypeSuggestionsWriter`; shared
+`SchemaTypeMapper` (formerly `OpenApiTypeMapper`).

--- a/inspector/build.gradle.kts
+++ b/inspector/build.gradle.kts
@@ -13,4 +13,7 @@ dependencies {
 
     // Protobuf FileDescriptorSet ingestion
     implementation(libs.protobuf.java)
+
+    // Test-only: exercise the registered regex generator end-to-end (JsonSchemaRegexRoundTripTest).
+    testImplementation(libs.datafaker)
 }

--- a/inspector/src/main/java/com/datagenerator/inspector/FakerTypeSuggestionsWriter.java
+++ b/inspector/src/main/java/com/datagenerator/inspector/FakerTypeSuggestionsWriter.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Marco Ferretti
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datagenerator.inspector;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Writes inspector-suggested custom Datafaker types (e.g. regex patterns discovered on schema
+ * fields) to a companion {@code inspect-faker-types.yaml} the user can feed back via {@code
+ * --faker-types}. Written in the same shape {@code CustomTypeConfigLoader} reads ({@code types:}
+ * map of name → expression).
+ *
+ * <p>Never clobbers: an existing file is left untouched unless {@code force} is set, and the target
+ * is refused outright if it is the very {@code --faker-types} input the run was given — so a
+ * hand-tuned config can't be silently overwritten. Callers log the suggestions on a skip so nothing
+ * is lost.
+ */
+public class FakerTypeSuggestionsWriter {
+
+  /** Fixed companion file name, written under the inspect output directory. */
+  public static final String FILE_NAME = "inspect-faker-types.yaml";
+
+  /** Outcome of a write attempt. */
+  public enum Result {
+    /** Nothing to write (no suggestions). */
+    NONE,
+    /** File written. */
+    WRITTEN,
+    /** Skipped: file already exists and {@code force} was not set. */
+    SKIPPED_EXISTS,
+    /** Skipped: target is the same file passed as {@code --faker-types} input. */
+    SKIPPED_IS_INPUT
+  }
+
+  private final YAMLMapper yaml =
+      new YAMLMapper(
+          YAMLFactory.builder().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER).build());
+
+  /**
+   * Writes {@code suggestions} (type name → expression, e.g. {@code regex:...}) to {@link
+   * #FILE_NAME} under {@code outputDir}.
+   *
+   * @param fakerTypesInput the {@code --faker-types} input path, or null; the target is refused if
+   *     it resolves to this file
+   * @return where the target resolved to, plus the outcome
+   */
+  public Outcome write(
+      Map<String, String> suggestions, Path outputDir, boolean force, Path fakerTypesInput) {
+    Path target = outputDir.resolve(FILE_NAME).normalize();
+    if (suggestions == null || suggestions.isEmpty()) {
+      return new Outcome(Result.NONE, target);
+    }
+    if (fakerTypesInput != null && target.equals(fakerTypesInput.normalize())) {
+      return new Outcome(Result.SKIPPED_IS_INPUT, target);
+    }
+    if (Files.exists(target) && !force) {
+      return new Outcome(Result.SKIPPED_EXISTS, target);
+    }
+    try {
+      Files.createDirectories(outputDir);
+      Files.writeString(target, render(suggestions));
+      return new Outcome(Result.WRITTEN, target);
+    } catch (IOException e) {
+      throw new InspectorException("Failed to write " + target, e);
+    }
+  }
+
+  /** Serializes the suggestions to the {@code types:} YAML shape (correct quoting/escaping). */
+  private String render(Map<String, String> suggestions) throws IOException {
+    Map<String, Object> root = new LinkedHashMap<>();
+    root.put("types", new LinkedHashMap<>(suggestions));
+    return yaml.writeValueAsString(root);
+  }
+
+  /** Where the companion file resolved to, and what happened. */
+  public record Outcome(Result result, Path target) {}
+}

--- a/inspector/src/main/java/com/datagenerator/inspector/Inspection.java
+++ b/inspector/src/main/java/com/datagenerator/inspector/Inspection.java
@@ -27,11 +27,23 @@ import java.util.Map;
  * @param comments review comments to emit, keyed by structure name then field name — only for
  *     flagged guesses (name hints, unknown types); declared and default-range fields are absent
  * @param warnings human-readable warnings (skipped schemas, etc.)
+ * @param fakerTypeSuggestions suggested custom Datafaker types keyed by type name → expression
+ *     (e.g. {@code code → regex:^[A-Z]{3}-\d{3}$}); the CLI writes these to a companion {@code
+ *     inspect-faker-types.yaml} the user can feed back via {@code --faker-types}
  */
 public record Inspection(
     List<DataStructure> structures,
     Map<String, Map<String, String>> comments,
-    List<String> warnings) {
+    List<String> warnings,
+    Map<String, String> fakerTypeSuggestions) {
+
+  /** Builds an inspection with no faker-type suggestions (OpenAPI / DDL / Protobuf sources). */
+  public static Inspection of(
+      List<DataStructure> structures,
+      Map<String, Map<String, String>> comments,
+      List<String> warnings) {
+    return new Inspection(structures, comments, warnings, Map.of());
+  }
 
   /** Total number of flagged fields across all structures. */
   public int flaggedCount() {

--- a/inspector/src/main/java/com/datagenerator/inspector/Names.java
+++ b/inspector/src/main/java/com/datagenerator/inspector/Names.java
@@ -46,6 +46,29 @@ public final class Names {
   }
 
   /**
+   * Validates that a structure name is a single safe path segment (CWE-22 guard). The name is
+   * derived from an untrusted source (schema key/title/{@code $id}/file name), so a value like
+   * {@code ../../etc/x} or one containing a path separator must not be allowed to redirect a later
+   * file write. Shared by {@code StructureYamlWriter} (emitted-file naming) and the inspectors
+   * (root-schema naming) so the two can't diverge.
+   *
+   * @return the name unchanged when safe
+   * @throws InspectorException if the name is null/blank or not a plain single path segment
+   */
+  public static String requireSafeStructureName(String name) {
+    if (name == null
+        || name.isBlank()
+        || name.indexOf('/') >= 0
+        || name.indexOf('\\') >= 0
+        || name.indexOf('\0') >= 0
+        || name.contains("..")) {
+      throw new InspectorException(
+          "Refusing structure with unsafe name '" + name + "' (must be a plain file name)");
+    }
+    return name;
+  }
+
+  /**
    * Splits a name into lowercase word tokens on camelCase boundaries and on {@code _}/{@code
    * -}/whitespace separators. Returns an empty list for blank input.
    */

--- a/inspector/src/main/java/com/datagenerator/inspector/SchemaTypeMapper.java
+++ b/inspector/src/main/java/com/datagenerator/inspector/SchemaTypeMapper.java
@@ -14,23 +14,21 @@
  * limitations under the License.
  */
 
-package com.datagenerator.inspector.openapi;
+package com.datagenerator.inspector;
 
-import com.datagenerator.inspector.Defaults;
-import com.datagenerator.inspector.FakerTypes;
-import com.datagenerator.inspector.MappedType;
-import com.datagenerator.inspector.NameHints;
-import com.datagenerator.inspector.Names;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.StringJoiner;
 import java.util.function.Supplier;
 
 /**
- * Maps a single OpenAPI property schema to a SeedStream datatype string. Resolution order matches
- * {@code docs/INSPECT-V1-SPEC.md} §3: {@code $ref} → format → enum → bounded numeric → name hint →
- * type default.
+ * Maps a single JSON Schema property node to a SeedStream datatype string. Keys only on plain JSON
+ * Schema vocabulary ({@code $ref}, {@code type}, {@code format}, {@code enum}, {@code
+ * minimum}/{@code maximum}, {@code maxLength}, {@code minItems}/{@code maxItems}, {@code items}),
+ * so it is shared by both the OpenAPI and standalone JSON Schema inspectors. Resolution order
+ * matches {@code docs/INSPECT-V1-SPEC.md} §3: {@code $ref} → format → enum → bounded numeric → name
+ * hint → type default.
  */
-public final class OpenApiTypeMapper {
+public final class SchemaTypeMapper {
 
   private static final String MINIMUM = "minimum";
   private static final String MAXIMUM = "maximum";
@@ -119,7 +117,11 @@ public final class OpenApiTypeMapper {
     return values.toString();
   }
 
-  /** Extracts and snake_cases the schema name from a {@code $ref} pointer. */
+  /**
+   * Extracts and snake_cases the schema name from a {@code $ref} pointer. Takes the last path
+   * segment, so it resolves OpenAPI {@code #/components/schemas/Foo} and JSON Schema {@code
+   * #/$defs/Foo} / {@code #/definitions/Foo} pointers alike.
+   */
   private String refName(String ref) {
     String last = ref.substring(ref.lastIndexOf('/') + 1);
     return Names.toSnakeCase(last);

--- a/inspector/src/main/java/com/datagenerator/inspector/StructureYamlWriter.java
+++ b/inspector/src/main/java/com/datagenerator/inspector/StructureYamlWriter.java
@@ -78,17 +78,7 @@ public class StructureYamlWriter {
    * @throws InspectorException if the name is unsafe or escapes {@code outputDir}
    */
   private static Path safeOutputFile(Path outputDir, String name) {
-    if (name == null
-        || name.isBlank()
-        || name.indexOf('/') >= 0
-        || name.indexOf('\\') >= 0
-        || name.indexOf('\0') >= 0
-        || name.contains("..")) {
-      throw new InspectorException(
-          "Refusing to write structure with unsafe name '"
-              + name
-              + "' (must be a plain file name)");
-    }
+    Names.requireSafeStructureName(name);
     Path base = outputDir.normalize();
     Path file = base.resolve(name + ".yaml").normalize();
     if (!file.startsWith(base) || file.equals(base)) {

--- a/inspector/src/main/java/com/datagenerator/inspector/ddl/DdlInspector.java
+++ b/inspector/src/main/java/com/datagenerator/inspector/ddl/DdlInspector.java
@@ -117,7 +117,7 @@ public class DdlInspector {
       Inspection nested = new NestingPlanner().plan(tables, nesting);
       List<String> all = new ArrayList<>(warnings);
       all.addAll(nested.warnings());
-      return new Inspection(nested.structures(), nested.comments(), all);
+      return Inspection.of(nested.structures(), nested.comments(), all);
     }
     return toInspection(tables, warnings);
   }
@@ -166,7 +166,7 @@ public class DdlInspector {
         comments.put(table.name(), table.comments());
       }
     }
-    return new Inspection(structures, comments, warnings);
+    return Inspection.of(structures, comments, warnings);
   }
 
   private TableInfo toTableInfo(CreateTable createTable, int order, List<String> warnings) {

--- a/inspector/src/main/java/com/datagenerator/inspector/ddl/NestingPlanner.java
+++ b/inspector/src/main/java/com/datagenerator/inspector/ddl/NestingPlanner.java
@@ -323,7 +323,7 @@ public final class NestingPlanner {
         comments.put(t.name(), new LinkedHashMap<>(t.comments()));
       }
     }
-    return new Inspection(structures, comments, warnings);
+    return Inspection.of(structures, comments, warnings);
   }
 
   private static boolean containsIgnoreCase(Collection<String> values, String target) {

--- a/inspector/src/main/java/com/datagenerator/inspector/jsonschema/JsonSchemaGaps.java
+++ b/inspector/src/main/java/com/datagenerator/inspector/jsonschema/JsonSchemaGaps.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 Marco Ferretti
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datagenerator.inspector.jsonschema;
+
+import com.datagenerator.inspector.Names;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Detects JSON Schema constructs that have no clean SeedStream equivalent. These are flagged with a
+ * {@code # review} comment plus a warning rather than mapped to a misleading structure — false
+ * confidence is worse than an explicit gap (see issue #89, {@code docs/INSPECT-V1-SPEC.md}).
+ */
+public final class JsonSchemaGaps {
+
+  private JsonSchemaGaps() {}
+
+  private static final String ONE_OF = "oneOf";
+  private static final String ANY_OF = "anyOf";
+  private static final String ALL_OF = "allOf";
+  private static final List<String> COMPOSITION = List.of(ONE_OF, ANY_OF, ALL_OF);
+
+  /**
+   * Returns a human-readable review reason if a single <em>property</em> schema uses a construct
+   * that cannot be mapped to one datatype, otherwise empty. A property occupies a single field
+   * slot, so composition/conditionals on it (unlike at the structure level, where sibling fields
+   * can be merged) have no representation.
+   *
+   * @param node the property schema node
+   * @param currentStructure the snake_case name of the structure being built, for recursive-{@code
+   *     $ref} detection (may be null)
+   */
+  public static Optional<String> unsupported(JsonNode node, String currentStructure) {
+    if (node == null || !node.isObject()) {
+      return Optional.empty();
+    }
+    for (String keyword : COMPOSITION) {
+      if (node.has(keyword)) {
+        return Optional.of(keyword + " schema composition — no SeedStream equivalent, map by hand");
+      }
+    }
+    if (node.has("if") || node.has("then") || node.has("else")) {
+      return Optional.of("if/then/else conditional schema — no SeedStream equivalent, map by hand");
+    }
+    if (node.has("patternProperties")) {
+      return Optional.of("patternProperties (open map) — no SeedStream equivalent, map by hand");
+    }
+    JsonNode additional = node.get("additionalProperties");
+    if (additional != null && additional.isBoolean() && additional.booleanValue()) {
+      return Optional.of(
+          "additionalProperties: true (open map) — no SeedStream equivalent, map by hand");
+    }
+    if (node.has("const")) {
+      return Optional.of("const value — no SeedStream equivalent, map by hand");
+    }
+    if (node.has("not")) {
+      return Optional.of("not schema — no SeedStream equivalent, map by hand");
+    }
+    JsonNode items = node.get("items");
+    if (items != null && items.isArray()) {
+      return Optional.of(
+          "tuple-form items (array of schemas) — no SeedStream equivalent, map by hand");
+    }
+    return refGap(node, currentStructure);
+  }
+
+  private static Optional<String> refGap(JsonNode node, String currentStructure) {
+    JsonNode ref = node.get("$ref");
+    if (ref == null || !ref.isTextual()) {
+      return Optional.empty();
+    }
+    String pointer = ref.asText();
+    if (!pointer.startsWith("#")) {
+      return Optional.of(
+          "external $ref '" + pointer + "' — only local $defs/definitions supported, map by hand");
+    }
+    if (currentStructure != null) {
+      String target = Names.toSnakeCase(pointer.substring(pointer.lastIndexOf('/') + 1));
+      if (currentStructure.equals(target)) {
+        return Optional.of(
+            "recursive $ref '" + pointer + "' — verify generation depth (circular refs fail fast)");
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Schema-level keywords whose <em>relationship</em> can't be represented after the structure is
+   * flattened, so their presence warrants a warning. Note {@code allOf} is deliberately absent: an
+   * {@code allOf} of object schemas is an exact merge (the common "extends" idiom) and is honoured,
+   * not flagged. The lossy branches ({@code oneOf}/{@code anyOf}/{@code if}/…) still have their
+   * fields merged in, but the record may then not validate — hence the warning.
+   */
+  private static final List<String> OBJECT_LEVEL =
+      List.of(
+          ONE_OF,
+          ANY_OF,
+          "if",
+          "then",
+          "else",
+          "not",
+          "dependentSchemas",
+          "dependentRequired",
+          "patternProperties");
+
+  /**
+   * Detects schema-level (whole-object, not per-property) constructs whose relationship is not
+   * enforced after flattening. Returns the keywords present, in declaration order; empty when none.
+   */
+  public static List<String> unsupportedObjectKeywords(JsonNode schemaNode) {
+    if (schemaNode == null || !schemaNode.isObject()) {
+      return List.of();
+    }
+    List<String> found = new ArrayList<>();
+    for (String keyword : OBJECT_LEVEL) {
+      if (schemaNode.has(keyword)) {
+        found.add(keyword);
+      }
+    }
+    JsonNode additional = schemaNode.get("additionalProperties");
+    if (additional != null && additional.isBoolean() && additional.booleanValue()) {
+      found.add("additionalProperties:true");
+    }
+    return found;
+  }
+
+  /**
+   * Property names merged in from a <em>lossy</em> branch ({@code oneOf}/{@code anyOf}/{@code
+   * if}/{@code then}/{@code else}/{@code dependentSchemas}) — their conditional/polymorphic
+   * relationship is dropped once flattened, so the affected fields get an inline review comment.
+   * {@code allOf} is excluded: its merge is exact and needs no comment.
+   */
+  public static Set<String> conditionallyConstrainedFields(JsonNode schemaNode) {
+    if (schemaNode == null || !schemaNode.isObject()) {
+      return Set.of();
+    }
+    Set<String> names = new LinkedHashSet<>();
+    for (String keyword : List.of("if", "then", "else")) {
+      collectBranchProps(schemaNode.get(keyword), names);
+    }
+    for (String keyword : List.of(ONE_OF, ANY_OF)) {
+      JsonNode array = schemaNode.get(keyword);
+      if (array != null && array.isArray()) {
+        array.forEach(branch -> collectBranchProps(branch, names));
+      }
+    }
+    JsonNode dependent = schemaNode.get("dependentSchemas");
+    if (dependent != null && dependent.isObject()) {
+      dependent.forEach(branch -> collectBranchProps(branch, names));
+    }
+    return names;
+  }
+
+  private static void collectBranchProps(JsonNode branch, Set<String> names) {
+    if (branch == null || !branch.isObject()) {
+      return;
+    }
+    JsonNode props = branch.get("properties");
+    if (props != null && props.isObject()) {
+      props.fieldNames().forEachRemaining(names::add);
+    }
+  }
+}

--- a/inspector/src/main/java/com/datagenerator/inspector/jsonschema/JsonSchemaInspector.java
+++ b/inspector/src/main/java/com/datagenerator/inspector/jsonschema/JsonSchemaInspector.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2026 Marco Ferretti
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datagenerator.inspector.jsonschema;
+
+import com.datagenerator.inspector.Defaults;
+import com.datagenerator.inspector.Inspection;
+import com.datagenerator.inspector.InspectorException;
+import com.datagenerator.inspector.MappedType;
+import com.datagenerator.inspector.Names;
+import com.datagenerator.inspector.SchemaTypeMapper;
+import com.datagenerator.schema.model.DataStructure;
+import com.datagenerator.schema.model.FieldDefinition;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Reads a standalone JSON Schema (Draft 7 / 2020-12) and maps it to SeedStream {@link
+ * DataStructure} files: the root object schema plus every entry under {@code $defs} / {@code
+ * definitions}. Reuses {@link SchemaTypeMapper} for per-property mapping (the same mapper the
+ * OpenAPI inspector uses).
+ *
+ * <p><b>Composition/conditionals.</b> Because this is a data <em>generator</em>, the fields of
+ * every branch are emitted: {@code allOf}/{@code oneOf}/{@code anyOf}/{@code if}/{@code
+ * then}/{@code else}/{@code dependentSchemas} subschemas are merged (union, first field wins) into
+ * one record so nothing that could appear is dropped. {@code allOf} is an exact merge; the lossy
+ * branches drop their conditional relationship, so those fields get a {@code # review} comment and
+ * the structure a warning (the union record may not validate against the source). See {@code
+ * docs/INSPECT-V1-SPEC.md} §10.
+ */
+public class JsonSchemaInspector {
+
+  private static final String SCHEMA_PREFIX = "schema '";
+
+  private final SchemaTypeMapper mapper = new SchemaTypeMapper();
+
+  /** Inspects a JSON Schema file and returns the structures plus diagnostics. */
+  public Inspection inspect(Path schemaFile) {
+    JsonNode root = readSchema(schemaFile);
+
+    List<DataStructure> structures = new ArrayList<>();
+    Map<String, Map<String, String>> comments = new LinkedHashMap<>();
+    List<String> warnings = new ArrayList<>();
+    Map<String, String> fakerSuggestions = new LinkedHashMap<>();
+
+    JsonNode rootProperties = root.path("properties");
+    boolean hasRootObject = rootProperties.isObject() && !rootProperties.isEmpty();
+    JsonNode defs = root.path("$defs");
+    JsonNode definitions = root.path("definitions");
+    boolean hasDefs = defs.isObject() || definitions.isObject();
+
+    if (!hasRootObject && !hasDefs) {
+      throw new InspectorException(
+          "No object schema, $defs, or definitions found in "
+              + schemaFile
+              + " — not a recognizable JSON Schema");
+    }
+
+    if (hasRootObject) {
+      DataStructure structure =
+          toStructure(rootName(root, schemaFile), root, root, comments, warnings, fakerSuggestions);
+      if (structure != null) {
+        structures.add(structure);
+      }
+    }
+    addDefs(defs, root, structures, comments, warnings, fakerSuggestions);
+    addDefs(definitions, root, structures, comments, warnings, fakerSuggestions);
+
+    return new Inspection(structures, comments, warnings, fakerSuggestions);
+  }
+
+  private void addDefs(
+      JsonNode defs,
+      JsonNode root,
+      List<DataStructure> structures,
+      Map<String, Map<String, String>> comments,
+      List<String> warnings,
+      Map<String, String> fakerSuggestions) {
+    if (!defs.isObject()) {
+      return;
+    }
+    for (Map.Entry<String, JsonNode> entry : defs.properties()) {
+      DataStructure structure =
+          toStructure(
+              Names.toSnakeCase(entry.getKey()),
+              entry.getValue(),
+              root,
+              comments,
+              warnings,
+              fakerSuggestions);
+      if (structure != null) {
+        structures.add(structure);
+      }
+    }
+  }
+
+  private DataStructure toStructure(
+      String name,
+      JsonNode schemaNode,
+      JsonNode root,
+      Map<String, Map<String, String>> comments,
+      List<String> warnings,
+      Map<String, String> fakerSuggestions) {
+    Map<String, JsonNode> properties = effectiveProperties(schemaNode, root);
+    if (properties.isEmpty()) {
+      warnings.add(SCHEMA_PREFIX + name + "' has no properties — skipped");
+      return null;
+    }
+
+    Set<String> branchFields = JsonSchemaGaps.conditionallyConstrainedFields(schemaNode);
+    Map<String, FieldDefinition> data = new LinkedHashMap<>();
+    Map<String, String> fieldComments = new LinkedHashMap<>();
+    for (Map.Entry<String, JsonNode> property : properties.entrySet()) {
+      String fieldName = property.getKey();
+      JsonNode fieldNode = property.getValue();
+
+      Optional<String> gap = JsonSchemaGaps.unsupported(fieldNode, name);
+      if (gap.isPresent()) {
+        fieldComments.put(fieldName, "review: " + gap.get());
+        warnings.add(SCHEMA_PREFIX + name + "' field '" + fieldName + "': " + gap.get());
+        data.put(fieldName, new FieldDefinition(Defaults.STRING, null));
+        continue;
+      }
+
+      MappedType mapped = mapper.map(fieldName, fieldNode);
+      if (mapped.flagged()) {
+        fieldComments.put(fieldName, mapped.comment());
+      }
+      data.put(fieldName, new FieldDefinition(mapped.datatype(), null));
+
+      suggestRegex(fieldName, fieldNode, fakerSuggestions, fieldComments);
+      if (branchFields.contains(fieldName)) {
+        fieldComments.putIfAbsent(
+            fieldName,
+            "review: merged from a conditional/composition branch — relationship not enforced");
+      }
+    }
+
+    flagSchemaLevelGaps(name, schemaNode, warnings);
+
+    if (!fieldComments.isEmpty()) {
+      comments.put(name, fieldComments);
+    }
+    return new DataStructure(name, null, data);
+  }
+
+  /**
+   * A {@code string} with a {@code pattern} has no inline SeedStream type. Record a regex custom
+   * type keyed by the field name (the CLI writes them to {@code inspect-faker-types.yaml}) and hint
+   * the field so a rerun with {@code --faker-types} resolves it by name.
+   */
+  private void suggestRegex(
+      String fieldName,
+      JsonNode fieldNode,
+      Map<String, String> fakerSuggestions,
+      Map<String, String> fieldComments) {
+    if (!"string".equals(fieldNode.path("type").asText("")) || !fieldNode.hasNonNull("pattern")) {
+      return;
+    }
+    String pattern = fieldNode.get("pattern").asText();
+    String typeName = Names.toSnakeCase(fieldName);
+    fakerSuggestions.putIfAbsent(typeName, "regex:" + pattern);
+    fieldComments.putIfAbsent(
+        fieldName,
+        "review: pattern '"
+            + pattern
+            + "' — add inspect-faker-types.yaml via --faker-types to generate matching values");
+  }
+
+  /**
+   * Warns when the structure carries a lossy schema-level relationship ({@code oneOf}/{@code if}/…)
+   * whose branches were merged but whose constraint can no longer be enforced.
+   */
+  private void flagSchemaLevelGaps(String name, JsonNode schemaNode, List<String> warnings) {
+    List<String> objectGaps = JsonSchemaGaps.unsupportedObjectKeywords(schemaNode);
+    if (objectGaps.isEmpty()) {
+      return;
+    }
+    warnings.add(
+        SCHEMA_PREFIX
+            + name
+            + "' has schema-level "
+            + String.join(", ", objectGaps)
+            + " — branch fields were merged into one record (union); the conditional/polymorphic"
+            + " relationship is NOT enforced, so generated records may not validate against the"
+            + " source. Review the # review fields.");
+  }
+
+  /**
+   * Collects the effective property set of an object schema: its own {@code properties} plus those
+   * merged in from {@code allOf}/{@code oneOf}/{@code anyOf}/{@code if}/{@code then}/{@code else}/
+   * {@code dependentSchemas} branches and local {@code $ref}s, first-declared wins. A visited-set
+   * on resolved {@code $ref}s guards against recursion.
+   */
+  private Map<String, JsonNode> effectiveProperties(JsonNode schemaNode, JsonNode root) {
+    Map<String, JsonNode> out = new LinkedHashMap<>();
+    collectProperties(schemaNode, root, out, new HashSet<>());
+    return out;
+  }
+
+  private void collectProperties(
+      JsonNode node, JsonNode root, Map<String, JsonNode> out, Set<String> visitedRefs) {
+    if (node == null || !node.isObject()) {
+      return;
+    }
+    JsonNode properties = node.get("properties");
+    if (properties != null && properties.isObject()) {
+      properties.properties().forEach(e -> out.putIfAbsent(e.getKey(), e.getValue()));
+    }
+    JsonNode ref = node.get("$ref");
+    if (ref != null
+        && ref.isTextual()
+        && ref.asText().startsWith("#/")
+        && visitedRefs.add(ref.asText())) {
+      collectProperties(resolvePointer(root, ref.asText()), root, out, visitedRefs);
+    }
+    for (String keyword : List.of("allOf", "oneOf", "anyOf")) {
+      JsonNode array = node.get(keyword);
+      if (array != null && array.isArray()) {
+        array.forEach(branch -> collectProperties(branch, root, out, visitedRefs));
+      }
+    }
+    for (String keyword : List.of("if", "then", "else")) {
+      collectProperties(node.get(keyword), root, out, visitedRefs);
+    }
+    JsonNode dependent = node.get("dependentSchemas");
+    if (dependent != null && dependent.isObject()) {
+      dependent.forEach(branch -> collectProperties(branch, root, out, visitedRefs));
+    }
+  }
+
+  /** Resolves a local JSON pointer ({@code #/$defs/Foo}) against the document root, or null. */
+  private JsonNode resolvePointer(JsonNode root, String pointer) {
+    JsonNode current = root;
+    for (String rawSegment : pointer.substring(2).split("/")) {
+      if (current == null) {
+        return null;
+      }
+      String segment = rawSegment.replace("~1", "/").replace("~0", "~");
+      current = current.get(segment);
+    }
+    return current;
+  }
+
+  /**
+   * Derives the root structure name: {@code title} → {@code $id} last segment → file name stem, run
+   * through the shared safe-name guard so it can never redirect a later write.
+   */
+  private String rootName(JsonNode root, Path schemaFile) {
+    String candidate = null;
+    if (root.hasNonNull("title")) {
+      candidate = root.get("title").asText();
+    } else if (root.hasNonNull("$id")) {
+      String id = root.get("$id").asText();
+      candidate = stripSchemaSuffix(id.substring(id.lastIndexOf('/') + 1));
+    }
+    if (candidate == null || candidate.isBlank()) {
+      Path fileName = schemaFile.getFileName();
+      candidate = stripSchemaSuffix(fileName == null ? "" : fileName.toString());
+    }
+    return Names.requireSafeStructureName(Names.toSnakeCase(candidate));
+  }
+
+  private String stripSchemaSuffix(String name) {
+    return name.replaceFirst("(?i)\\.schema\\.json$", "").replaceFirst("(?i)\\.(json|ya?ml)$", "");
+  }
+
+  private JsonNode readSchema(Path schemaFile) {
+    ObjectMapper objectMapper =
+        schemaFile.toString().endsWith(".json") ? new ObjectMapper() : new YAMLMapper();
+    try {
+      return objectMapper.readTree(schemaFile.toFile());
+    } catch (IOException e) {
+      throw new InspectorException("Failed to read JSON Schema: " + schemaFile, e);
+    }
+  }
+}

--- a/inspector/src/main/java/com/datagenerator/inspector/openapi/OpenApiInspector.java
+++ b/inspector/src/main/java/com/datagenerator/inspector/openapi/OpenApiInspector.java
@@ -20,6 +20,7 @@ import com.datagenerator.inspector.Inspection;
 import com.datagenerator.inspector.InspectorException;
 import com.datagenerator.inspector.MappedType;
 import com.datagenerator.inspector.Names;
+import com.datagenerator.inspector.SchemaTypeMapper;
 import com.datagenerator.schema.model.DataStructure;
 import com.datagenerator.schema.model.FieldDefinition;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -38,7 +39,7 @@ import java.util.Map;
  */
 public class OpenApiInspector {
 
-  private final OpenApiTypeMapper mapper = new OpenApiTypeMapper();
+  private final SchemaTypeMapper mapper = new SchemaTypeMapper();
 
   /** Inspects an OpenAPI spec file and returns the structures plus diagnostics. */
   public Inspection inspect(Path specFile) {
@@ -60,7 +61,7 @@ public class OpenApiInspector {
       }
     }
 
-    return new Inspection(structures, comments, warnings);
+    return Inspection.of(structures, comments, warnings);
   }
 
   private DataStructure toStructure(

--- a/inspector/src/main/java/com/datagenerator/inspector/protobuf/ProtobufInspector.java
+++ b/inspector/src/main/java/com/datagenerator/inspector/protobuf/ProtobufInspector.java
@@ -78,7 +78,7 @@ public class ProtobufInspector {
       }
     }
 
-    return new Inspection(structures, comments, warnings);
+    return Inspection.of(structures, comments, warnings);
   }
 
   private byte[] readBytes(Path file) {

--- a/inspector/src/main/java/com/datagenerator/inspector/protobuf/ProtobufTypeMapper.java
+++ b/inspector/src/main/java/com/datagenerator/inspector/protobuf/ProtobufTypeMapper.java
@@ -27,7 +27,7 @@ import java.util.StringJoiner;
 
 /**
  * Maps a single protobuf {@link FieldDescriptor} to a SeedStream datatype string. Mirrors the
- * resolution logic of {@code OpenApiTypeMapper} adapted for the protobuf type system.
+ * resolution logic of {@code SchemaTypeMapper} adapted for the protobuf type system.
  */
 public final class ProtobufTypeMapper {
 

--- a/inspector/src/test/java/com/datagenerator/inspector/FakerTypeSuggestionsWriterTest.java
+++ b/inspector/src/test/java/com/datagenerator/inspector/FakerTypeSuggestionsWriterTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Marco Ferretti
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datagenerator.inspector;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.datagenerator.inspector.FakerTypeSuggestionsWriter.Result;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FakerTypeSuggestionsWriterTest {
+
+  private final FakerTypeSuggestionsWriter writer = new FakerTypeSuggestionsWriter();
+  private final Map<String, String> suggestions = Map.of("sku", "regex:^[A-Z]{3}$");
+
+  @Test
+  void shouldWriteLoadableTypesYaml(@TempDir Path dir) throws IOException {
+    FakerTypeSuggestionsWriter.Outcome outcome = writer.write(suggestions, dir, false, null);
+
+    assertThat(outcome.result()).isEqualTo(Result.WRITTEN);
+    assertThat(outcome.target()).isEqualTo(dir.resolve(FakerTypeSuggestionsWriter.FILE_NAME));
+    String body = Files.readString(outcome.target());
+    assertThat(body).contains("types:").contains("sku:").contains("regex:^[A-Z]{3}$");
+  }
+
+  @Test
+  void shouldReturnNoneWhenNoSuggestions(@TempDir Path dir) {
+    assertThat(writer.write(Map.of(), dir, false, null).result()).isEqualTo(Result.NONE);
+  }
+
+  @Test
+  void shouldNotClobberExistingFileWithoutForce(@TempDir Path dir) throws IOException {
+    Path target = dir.resolve(FakerTypeSuggestionsWriter.FILE_NAME);
+    Files.writeString(target, "types:\n  hand_tuned: uuid\n");
+
+    assertThat(writer.write(suggestions, dir, false, null).result())
+        .isEqualTo(Result.SKIPPED_EXISTS);
+    // untouched
+    assertThat(Files.readString(target)).contains("hand_tuned");
+  }
+
+  @Test
+  void shouldOverwriteExistingFileWithForce(@TempDir Path dir) throws IOException {
+    Path target = dir.resolve(FakerTypeSuggestionsWriter.FILE_NAME);
+    Files.writeString(target, "types:\n  hand_tuned: uuid\n");
+
+    assertThat(writer.write(suggestions, dir, true, null).result()).isEqualTo(Result.WRITTEN);
+    assertThat(Files.readString(target)).contains("sku").doesNotContain("hand_tuned");
+  }
+
+  @Test
+  void shouldRefuseToOverwriteFakerTypesInput(@TempDir Path dir) throws IOException {
+    // The run's --faker-types input happens to resolve to the companion path — must never clobber.
+    Path input = dir.resolve(FakerTypeSuggestionsWriter.FILE_NAME);
+    Files.writeString(input, "types:\n  mine: uuid\n");
+
+    assertThat(writer.write(suggestions, dir, true, input).result())
+        .isEqualTo(Result.SKIPPED_IS_INPUT);
+    assertThat(Files.readString(input)).contains("mine");
+  }
+}

--- a/inspector/src/test/java/com/datagenerator/inspector/jsonschema/JsonSchemaGapsTest.java
+++ b/inspector/src/test/java/com/datagenerator/inspector/jsonschema/JsonSchemaGapsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 Marco Ferretti
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datagenerator.inspector.jsonschema;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class JsonSchemaGapsTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "{ \"oneOf\": [] }",
+        "{ \"anyOf\": [] }",
+        "{ \"allOf\": [] }",
+        "{ \"if\": {}, \"then\": {} }",
+        "{ \"patternProperties\": {} }",
+        "{ \"additionalProperties\": true }",
+        "{ \"const\": 5 }",
+        "{ \"not\": {} }",
+        "{ \"type\": \"array\", \"items\": [ { \"type\": \"string\" } ] }",
+        "{ \"$ref\": \"other.json#/$defs/Foo\" }",
+        "{ \"$ref\": \"https://example.com/x.json\" }"
+      })
+  void shouldFlagUnsupportedConstructs(String json) throws Exception {
+    assertThat(JsonSchemaGaps.unsupported(node(json), "current")).isPresent();
+  }
+
+  @Test
+  void shouldFlagRecursiveLocalRef() throws Exception {
+    Optional<String> reason =
+        JsonSchemaGaps.unsupported(node("{ \"$ref\": \"#/$defs/Tree\" }"), "tree");
+    assertThat(reason).isPresent();
+    assertThat(reason.get()).contains("recursive");
+  }
+
+  @Test
+  void shouldNotFlagPlainLocalRef() throws Exception {
+    // a non-recursive local $ref is mapped normally by SchemaTypeMapper, not a gap
+    assertThat(JsonSchemaGaps.unsupported(node("{ \"$ref\": \"#/$defs/LineItem\" }"), "order"))
+        .isEmpty();
+  }
+
+  @Test
+  void shouldNotFlagAdditionalPropertiesFalseOrSchema() throws Exception {
+    assertThat(JsonSchemaGaps.unsupported(node("{ \"additionalProperties\": false }"), null))
+        .isEmpty();
+    assertThat(
+            JsonSchemaGaps.unsupported(
+                node("{ \"additionalProperties\": { \"type\": \"string\" } }"), null))
+        .isEmpty();
+  }
+
+  @Test
+  void shouldNotFlagOrdinaryScalar() throws Exception {
+    assertThat(JsonSchemaGaps.unsupported(node("{ \"type\": \"string\" }"), null)).isEmpty();
+  }
+
+  @Test
+  void shouldDetectSchemaLevelKeywords() throws Exception {
+    String schema =
+        "{ \"type\": \"object\", \"properties\": { \"a\": { \"type\": \"string\" } },"
+            + " \"if\": {}, \"then\": {}, \"else\": {}, \"dependentSchemas\": {} }";
+    assertThat(JsonSchemaGaps.unsupportedObjectKeywords(node(schema)))
+        .containsExactly("if", "then", "else", "dependentSchemas");
+  }
+
+  @Test
+  void shouldDetectAdditionalPropertiesTrueAtObjectLevel() throws Exception {
+    assertThat(JsonSchemaGaps.unsupportedObjectKeywords(node("{ \"additionalProperties\": true }")))
+        .containsExactly("additionalProperties:true");
+  }
+
+  @Test
+  void shouldReturnNoSchemaLevelKeywordsForPlainObject() throws Exception {
+    assertThat(
+            JsonSchemaGaps.unsupportedObjectKeywords(
+                node("{ \"type\": \"object\", \"properties\": {} }")))
+        .isEmpty();
+  }
+
+  @Test
+  void shouldNotFlagAllOfAtObjectLevel() throws Exception {
+    // allOf is an exact merge, not a lossy relationship — it must not warn.
+    assertThat(JsonSchemaGaps.unsupportedObjectKeywords(node("{ \"allOf\": [] }"))).isEmpty();
+  }
+
+  @Test
+  void shouldCollectConditionallyConstrainedFields() throws Exception {
+    String schema =
+        "{ \"type\": \"object\","
+            + " \"if\": { \"properties\": { \"isMember\": { \"const\": true } } },"
+            + " \"then\": { \"properties\": { \"membershipNumber\": { \"minLength\": 10 } } } }";
+    assertThat(JsonSchemaGaps.conditionallyConstrainedFields(node(schema)))
+        .containsExactlyInAnyOrder("isMember", "membershipNumber");
+  }
+
+  private JsonNode node(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/inspector/src/test/java/com/datagenerator/inspector/jsonschema/JsonSchemaInspectorTest.java
+++ b/inspector/src/test/java/com/datagenerator/inspector/jsonschema/JsonSchemaInspectorTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2026 Marco Ferretti
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datagenerator.inspector.jsonschema;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.datagenerator.inspector.Inspection;
+import com.datagenerator.inspector.InspectorException;
+import com.datagenerator.schema.model.DataStructure;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JsonSchemaInspectorTest {
+
+  // JSON kept as concatenated strings rather than a text block: google-java-format mangles a
+  // text block whose first content line begins with '{'.
+  private static final String SCHEMA =
+      "{"
+          + "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\","
+          + "  \"title\": \"Order\","
+          + "  \"type\": \"object\","
+          + "  \"properties\": {"
+          + "    \"id\": { \"type\": \"string\", \"format\": \"uuid\" },"
+          + "    \"total\": { \"type\": \"number\", \"minimum\": 0, \"maximum\": 5000 },"
+          + "    \"status\": { \"type\": \"string\", \"enum\": [\"NEW\", \"SHIPPED\"] },"
+          + "    \"lines\": {"
+          + "      \"type\": \"array\", \"minItems\": 1, \"maxItems\": 5,"
+          + "      \"items\": { \"$ref\": \"#/$defs/LineItem\" }"
+          + "    },"
+          + "    \"kind\": { \"oneOf\": [ { \"type\": \"string\" }, { \"type\": \"integer\" } ] }"
+          + "  },"
+          + "  \"$defs\": {"
+          + "    \"LineItem\": {"
+          + "      \"type\": \"object\","
+          + "      \"properties\": {"
+          + "        \"sku\": { \"type\": \"string\", \"maxLength\": 20 },"
+          + "        \"qty\": { \"type\": \"integer\", \"minimum\": 1 }"
+          + "      }"
+          + "    }"
+          + "  },"
+          + "  \"definitions\": {"
+          + "    \"LegacyRef\": {"
+          + "      \"type\": \"object\","
+          + "      \"properties\": { \"code\": { \"type\": \"string\" } }"
+          + "    }"
+          + "  }"
+          + "}";
+
+  @Test
+  void shouldEmitRootDefsAndDefinitionsAsStructures(@TempDir Path dir) throws IOException {
+    Inspection inspection = inspect(dir, "order.schema.json", SCHEMA);
+
+    assertThat(inspection.structures())
+        .extracting(DataStructure::getName)
+        .containsExactlyInAnyOrder("order", "line_item", "legacy_ref");
+  }
+
+  @Test
+  void shouldMapRootPropertiesIncludingLocalRef(@TempDir Path dir) throws IOException {
+    Map<String, String> order = datatypesOf(inspect(dir, "order.schema.json", SCHEMA), "order");
+
+    assertThat(order)
+        .containsEntry("id", "uuid")
+        .containsEntry("total", "decimal[0..5000]")
+        .containsEntry("status", "enum[NEW,SHIPPED]")
+        // $ref #/$defs/LineItem resolves to the snake_case structure name
+        .containsEntry("lines", "array[object[line_item], 1..5]");
+  }
+
+  @Test
+  void shouldMapNestedDefProperties(@TempDir Path dir) throws IOException {
+    Map<String, String> lineItem =
+        datatypesOf(inspect(dir, "order.schema.json", SCHEMA), "line_item");
+
+    assertThat(lineItem).containsEntry("sku", "char[1..20]").containsEntry("qty", "int[1..999999]");
+  }
+
+  @Test
+  void shouldFlagUnsupportedConstructWithReviewCommentAndWarning(@TempDir Path dir)
+      throws IOException {
+    Inspection inspection = inspect(dir, "order.schema.json", SCHEMA);
+
+    // oneOf has no SeedStream equivalent: placeholder datatype + review comment + warning
+    assertThat(datatypesOf(inspection, "order")).containsEntry("kind", "char[1..50]");
+    assertThat(inspection.comments().get("order").get("kind"))
+        .startsWith("review:")
+        .contains("oneOf");
+    assertThat(inspection.warnings()).anyMatch(w -> w.contains("kind") && w.contains("oneOf"));
+    assertThat(inspection.flaggedCount()).isPositive();
+  }
+
+  @Test
+  void shouldNameRootFromIdWhenNoTitle(@TempDir Path dir) throws IOException {
+    String schema =
+        "{"
+            + "  \"$id\": \"https://example.com/schemas/Address.schema.json\","
+            + "  \"type\": \"object\","
+            + "  \"properties\": { \"city\": { \"type\": \"string\" } }"
+            + "}";
+    Inspection inspection = inspect(dir, "whatever.json", schema);
+
+    assertThat(inspection.structures()).extracting(DataStructure::getName).contains("address");
+  }
+
+  @Test
+  void shouldNameRootFromFileNameWhenNoTitleOrId(@TempDir Path dir) throws IOException {
+    String schema =
+        "{ \"type\": \"object\", \"properties\": { \"city\": { \"type\": \"string\" } } }";
+    Inspection inspection = inspect(dir, "customer.schema.json", schema);
+
+    assertThat(inspection.structures()).extracting(DataStructure::getName).contains("customer");
+  }
+
+  @Test
+  void shouldFlagRootLevelConditionalSchema(@TempDir Path dir) throws IOException {
+    // Mirrors json-schema.org's "Conditional Validation with If-Else" example: the if/then/else
+    // sits at the root, beside properties — it must not be silently dropped.
+    String schema =
+        "{"
+            + "  \"title\": \"Membership\","
+            + "  \"type\": \"object\","
+            + "  \"properties\": {"
+            + "    \"isMember\": { \"type\": \"boolean\" },"
+            + "    \"membershipNumber\": { \"type\": \"string\" }"
+            + "  },"
+            + "  \"if\": { \"properties\": { \"isMember\": { \"const\": true } } },"
+            + "  \"then\": { \"properties\": { \"membershipNumber\": { \"minLength\": 10 } } },"
+            + "  \"else\": { \"properties\": { \"membershipNumber\": { \"minLength\": 15 } } }"
+            + "}";
+    Inspection inspection = inspect(dir, "membership.schema.json", schema);
+
+    assertThat(inspection.warnings()).anyMatch(w -> w.contains("schema-level") && w.contains("if"));
+    // the conditionally-constrained field gets an inline review comment
+    assertThat(inspection.comments().get("membership").get("membershipNumber"))
+        .startsWith("review:")
+        .contains("conditional");
+    assertThat(inspection.flaggedCount()).isPositive();
+  }
+
+  @Test
+  void shouldMergeAllOfWithoutWarning(@TempDir Path dir) throws IOException {
+    // allOf of object schemas is an exact merge (the "extends" idiom) — union the fields, no
+    // warning.
+    String schema =
+        "{"
+            + "  \"title\": \"Account\","
+            + "  \"type\": \"object\","
+            + "  \"properties\": { \"id\": { \"type\": \"integer\" } },"
+            + "  \"allOf\": ["
+            + "    { \"properties\": { \"owner\": { \"type\": \"string\" } } },"
+            + "    { \"properties\": { \"active\": { \"type\": \"boolean\" } } }"
+            + "  ]"
+            + "}";
+    Inspection inspection = inspect(dir, "account.schema.json", schema);
+
+    assertThat(datatypesOf(inspection, "account")).containsKeys("id", "owner", "active");
+    assertThat(inspection.warnings()).noneMatch(w -> w.contains("schema-level"));
+  }
+
+  @Test
+  void shouldUnionOneOfVariantsAndWarn(@TempDir Path dir) throws IOException {
+    // oneOf variants are unioned so every possible field is emitted; the relationship is flagged.
+    String schema =
+        "{"
+            + "  \"title\": \"Shape\","
+            + "  \"type\": \"object\","
+            + "  \"properties\": { \"kind\": { \"type\": \"string\" } },"
+            + "  \"oneOf\": ["
+            + "    { \"properties\": { \"radius\": { \"type\": \"number\" } } },"
+            + "    { \"properties\": { \"side\": { \"type\": \"number\" } } }"
+            + "  ]"
+            + "}";
+    Inspection inspection = inspect(dir, "shape.schema.json", schema);
+
+    assertThat(datatypesOf(inspection, "shape")).containsKeys("kind", "radius", "side");
+    assertThat(inspection.warnings())
+        .anyMatch(w -> w.contains("schema-level") && w.contains("oneOf"));
+    assertThat(inspection.comments().get("shape")).containsKey("radius").containsKey("side");
+  }
+
+  @Test
+  void shouldSuggestRegexFakerTypeForPatternedField(@TempDir Path dir) throws IOException {
+    String schema =
+        "{"
+            + "  \"title\": \"Code\","
+            + "  \"type\": \"object\","
+            + "  \"properties\": { \"sku\": { \"type\": \"string\", \"pattern\": \"^[A-Z]{3}$\" } }"
+            + "}";
+    Inspection inspection = inspect(dir, "code.schema.json", schema);
+
+    assertThat(inspection.fakerTypeSuggestions()).containsEntry("sku", "regex:^[A-Z]{3}$");
+    assertThat(inspection.comments().get("code").get("sku")).contains("pattern");
+  }
+
+  @Test
+  void shouldFailWhenNoObjectSchemaOrDefs(@TempDir Path dir) throws IOException {
+    Path file = dir.resolve("scalar.schema.json");
+    Files.writeString(file, "{ \"$schema\": \"x\", \"type\": \"string\" }");
+    JsonSchemaInspector inspector = new JsonSchemaInspector();
+
+    assertThatThrownBy(() -> inspector.inspect(file))
+        .isInstanceOf(InspectorException.class)
+        .hasMessageContaining("not a recognizable JSON Schema");
+  }
+
+  private Inspection inspect(Path dir, String fileName, String content) throws IOException {
+    Path file = dir.resolve(fileName);
+    Files.writeString(file, content);
+    return new JsonSchemaInspector().inspect(file);
+  }
+
+  private Map<String, String> datatypesOf(Inspection inspection, String structureName) {
+    DataStructure structure =
+        inspection.structures().stream()
+            .filter(s -> s.getName().equals(structureName))
+            .findFirst()
+            .orElseThrow();
+    return structure.getData().entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getDatatype(), (a, b) -> a));
+  }
+}

--- a/inspector/src/test/java/com/datagenerator/inspector/jsonschema/JsonSchemaRegexRoundTripTest.java
+++ b/inspector/src/test/java/com/datagenerator/inspector/jsonschema/JsonSchemaRegexRoundTripTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Marco Ferretti
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datagenerator.inspector.jsonschema;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.datagenerator.core.registry.DatafakerRegistry;
+import com.datagenerator.inspector.FakerTypeSuggestionsWriter;
+import com.datagenerator.inspector.Inspection;
+import com.datagenerator.schema.model.DataStructure;
+import com.datagenerator.schema.parser.CustomTypeConfigLoader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Random;
+import net.datafaker.Faker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Full round-trip for the regex bootstrap loop: a {@code pattern} field is inspected → the
+ * suggested custom type is written and registered → re-inspecting upgrades the field's datatype →
+ * the registered generator actually produces values that match the pattern. This is the automated
+ * counterpart to the manual {@code inspect → --faker-types → execute} flow.
+ */
+class JsonSchemaRegexRoundTripTest {
+
+  private static final String PATTERN = "^[A-Z]{3}-\\d{3}$";
+
+  // productCode -> snake_case type name "product_code"; kept distinctive to avoid registry clashes.
+  private static final String SCHEMA =
+      "{"
+          + "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\","
+          + "  \"title\": \"Product\","
+          + "  \"type\": \"object\","
+          + "  \"properties\": {"
+          + "    \"productCode\": { \"type\": \"string\", \"pattern\": \"^[A-Z]{3}-\\\\d{3}$\" }"
+          + "  }"
+          + "}";
+
+  @Test
+  void regexSuggestionRegistersAndGeneratesMatchingValues(@TempDir Path dir) throws IOException {
+    Path schemaFile = dir.resolve("product.schema.json");
+    Files.writeString(schemaFile, SCHEMA);
+
+    // 1. inspect surfaces the regex as a faker-type suggestion (field maps to char for now).
+    Inspection first = new JsonSchemaInspector().inspect(schemaFile);
+    assertThat(first.fakerTypeSuggestions()).containsEntry("product_code", "regex:" + PATTERN);
+    assertThat(datatypeOf(first, "product", "productCode")).isEqualTo("char[1..50]");
+
+    // 2. write the companion file and load it, exactly as the CLI + --faker-types would.
+    FakerTypeSuggestionsWriter.Outcome outcome =
+        new FakerTypeSuggestionsWriter().write(first.fakerTypeSuggestions(), dir, false, null);
+    assertThat(outcome.result()).isEqualTo(FakerTypeSuggestionsWriter.Result.WRITTEN);
+    assertThat(new CustomTypeConfigLoader().load(outcome.target())).isEqualTo(1);
+    assertThat(DatafakerRegistry.isRegistered("product_code")).isTrue();
+
+    // 3. re-inspecting now resolves the field to the registered type by name-hint.
+    Inspection second = new JsonSchemaInspector().inspect(schemaFile);
+    assertThat(datatypeOf(second, "product", "productCode")).isEqualTo("product_code");
+
+    // 4. the registered generator actually produces pattern-matching values.
+    Faker faker = new Faker(Locale.US, new Random(1));
+    Random random = new Random(1);
+    for (int i = 0; i < 25; i++) {
+      assertThat(DatafakerRegistry.generate("product_code", faker, random)).matches(PATTERN);
+    }
+  }
+
+  private String datatypeOf(Inspection inspection, String structure, String field) {
+    DataStructure ds =
+        inspection.structures().stream()
+            .filter(s -> s.getName().equals(structure))
+            .findFirst()
+            .orElseThrow();
+    return ds.getData().get(field).getDatatype();
+  }
+}


### PR DESCRIPTION
Closes #89.

## What

Adds standalone **JSON Schema** (Draft 7 / 2020-12) as a first-class `inspect` source, alongside OpenAPI, SQL DDL, and Protobuf. A bare `payload.schema.json` (AsyncAPI events, Kafka JSON-Schema registry, config contracts) no longer needs wrapping in a fake OpenAPI envelope.

## How

- **`JsonSchemaInspector`** — the root object schema plus every entry under `$defs`/`definitions` → one structure each; local `$ref` (`#/$defs`, `#/definitions`) → `object[...]`. Root name from `title` → `$id` → file stem, run through the shared safe-name guard.
- **`OpenApiTypeMapper` → `SchemaTypeMapper`** (moved to the inspector root package). It was already pure JSON-Schema vocabulary; now shared honestly by both inspectors (OpenAPI behaviour unchanged).
- **Composition/conditionals are merged, because `inspect` generates data.** `allOf`/`oneOf`/`anyOf`/`if`/`then`/`else`/`dependentSchemas` subschema fields (and local `$ref`s among them) are unioned into one record so nothing that could appear is dropped:
  - `allOf` is an exact merge (silent) — the common "extends" idiom.
  - the lossy branches still merge their fields but drop the relationship, so each gets a `# review` comment and the structure a warning that the union record may not validate.
  - per-property composition (a single datatype slot) stays flagged with a placeholder.
- **Regex (`pattern`)** has no inline SeedStream type, so `inspect` writes a companion **`inspect-faker-types.yaml`** (keyed by field name) and comments the field. Rerunning with `--faker-types` upgrades the field to the registered `regexify` generator. The companion file **never clobbers** an existing file or the `--faker-types` input.
- **CLI**: `--format jsonschema`; auto-detect `.schema.json`, plus a content-peek for `.json`/`.yaml` (`openapi`/`swagger` → OpenAPI, else `$schema`/`$defs`/`definitions` → JSON Schema, else OpenAPI).

## Tests

`JsonSchemaInspectorTest`, `JsonSchemaGapsTest`, `FakerTypeSuggestionsWriterTest` (incl. no-clobber / refuse-input), new CLI cases in `InspectCommandTest`, and `JsonSchemaRegexRoundTripTest` — the full loop: inspect → suggest → register → **generate**, asserting the generated values match the pattern. Verified end-to-end against the 8 published json-schema.org examples.

## Verification

- `./gradlew :inspector:test :cli:test spotlessCheck` — green.
- Local SonarQube quality gate: **PASS** (overall coverage 85.0%, new-code 81.2%, 0 new violations).

## Docs

`docs/INSPECT-V1-SPEC.md` §10 (entry points, merge semantics, regex loop, no-clobber).

## Follow-up (separate issue)

HTTP(S) URL input for `inspect` (OpenAPI + JSON Schema), reusing the seed `remote` HTTP+auth layer, SSRF-hardened once.