### PR TITLE
chore(skill): update seedstream-config for inspect + evolved type system

### DIFF
--- a/.claude/skills/seedstream-config/SKILL.md
+++ b/.claude/skills/seedstream-config/SKILL.md
@@ -1,31 +1,40 @@
 ---
 name: seedstream-config
+model: sonnet
 description: >
-  Interactive wizard for generating SeedStream structure YAML (records) and job YAML (destinations).
-  Asks clarifying questions, then writes the files to config/structures/ and config/jobs/.
-  Use when the user says "create a job", "generate a structure", "help me configure", "new record",
-  "new structure", "prepare a job", "add a destination", or invokes /seedstream-config.
+  Interactive wizard for SeedStream config: generate structure YAML (records) and job YAML
+  (destinations), OR bootstrap structures from an existing schema via `inspect`
+  (OpenAPI / JSON Schema / SQL DDL / Protobuf). Asks clarifying questions, then writes files to
+  config/structures/ and config/jobs/. Use when the user says "create a job", "generate a
+  structure", "help me configure", "new record", "new structure", "prepare a job", "add a
+  destination", "inspect", "import a schema", "bootstrap from OpenAPI/DDL/JSON Schema", or invokes
+  /seedstream-config.
 ---
 
-You are a SeedStream configuration expert. Generate structure and job YAML files for the user.
+You are a SeedStream configuration expert. Generate structure and job YAML, or bootstrap structures
+from an existing schema with `inspect`.
 
 ## Workflow
 
-1. **Identify intent**: Does the user want a record (structure), a job, or both?
-2. **Ask the minimum needed** — entity name, fields, destination. Don't ask for information you can infer from context or defaults.
-3. **Generate the YAML** and write it to the correct path.
-4. **Print the run command** so the user can test immediately.
+1. **Identify intent**: hand-write a record/job, or **bootstrap** from an existing schema file?
+   - Small & flat (≤ ~10 primitive fields) → hand-write (faster than inspect → review → fix).
+   - Large / nested / constraint-rich, or the user already has an OpenAPI/DDL/JSON Schema/Protobuf
+     → use `inspect` (see "Bootstrap from an existing schema").
+2. **Ask the minimum** — entity name, fields, destination. Don't ask what you can infer or default.
+3. **Generate/emit** and write to the correct path.
+4. **Print the run command** (`./seedstream …`) so the user can test immediately.
 
 ## File Locations
 
 - Structures → `config/structures/<name>.yaml`
 - Jobs → `config/jobs/<destination>_<name>.yaml`
+- `name:` field must equal the filename without `.yaml`.
 
 ## Structure YAML Template
 
 ```yaml
 name: <entity_name>
-geolocation: <locale>          # usa | italy | uk | germany | france | … (62 supported)
+geolocation: <locale>          # usa | italy | uk | germany | … (62 supported, see below)
 data:
   <field_name>:
     datatype: <type>
@@ -41,28 +50,97 @@ int[1..999]                    # random integer, inclusive
 decimal[0.01..999.99]          # random float
 boolean                        # true/false 50/50
 date[2020-01-01..2025-12-31]   # ISO-8601 date range
-timestamp[now-30d..now]        # relative or absolute datetime
-timestamp[2024-01-01T00:00:00..2025-12-31T23:59:59]
+timestamp[now-30d..now]        # relative window …
+timestamp[2024-01-01T00:00:00..2025-12-31T23:59:59]   # … or absolute
 enum[VAL1,VAL2,VAL3]           # uniform random pick
-```
-
-**Semantic (Datafaker — locale-aware)**
-```
-uuid          first_name    last_name     name
-email         phone_number  ssn           username
-address       city          state         country
-postal_code   latitude      longitude
-company       industry      job_title     department
-url           domain        ip_address
-iban          credit_card
 ```
 
 **Composite**
 ```
-object[other_structure]                      # nested object — loads other_structure.yaml
-array[char[5..10], 3..8]                     # 3–8 random strings
-array[object[line_item], 1..20]              # 1–20 nested objects
+object[other_structure]              # nested object — auto-loads other_structure.yaml
+array[char[5..10], 3..8]             # 3–8 random strings
+array[object[line_item], 1..20]      # 1–20 nested objects
 ```
+
+**Foreign keys (ref)** — pick from another structure's already-generated field:
+```
+ref[other_structure.field, 1..count]   # pool tied to record count (typical)
+ref[other_structure.field, 1..5000]    # or an explicit range
+```
+- The range is **required** — a bare `ref[s.field]` is rejected by the engine.
+- `count` resolves to the job's `--count`, so the emitted YAML scales at any volume.
+- Circular references are detected and fail fast.
+
+**Semantic (Datafaker — locale-aware)** — a bare registry key, e.g. `datatype: email`. The built-in
+keys (verify against `DatafakerRegistry` if unsure — do **not** invent keys):
+```
+Person:   first_name  last_name  full_name  name  username  prefix  suffix  title  occupation  ssn
+Contact:  email  phone_number
+Address:  address  city  state  country  country_code  postal_code  street_name  street_number
+          latitude  longitude  time_zone
+Internet: url  domain  ipv4  ipv6  mac_address  uuid  password
+Finance:  iban  random_iban  sepa_iban  bic  credit_card  credit_card_type  cvv  currency  price
+Commerce: company  department  material  color  product_name  promotion_code  isbn  stock_market
+Text:     lorem_word  lorem_sentence  lorem_paragraph  pokemon
+```
+Aliases exist for many (`phone`→`phone_number`, `zip`→`postal_code`, `swift`→`bic`, …). There is
+**no** `ip_address` (use `ipv4`/`ipv6`), no `job_title` (use `occupation`/`title`), no `industry`.
+Anything outside this set needs `--faker-types` (below). There is no `datafaker[...]` bracket syntax
+— the key stands alone.
+
+**Custom types (`--faker-types`)** — for datatypes not pre-registered (extra Datafaker providers or
+regex). Declare in a YAML config, pass it to `inspect`/`execute` with `--faker-types <file>`:
+```yaml
+types:
+  beer_style: beer.style                 # dot chain = no-arg Datafaker method calls
+  iso_msg_id: "regex:[A-Z0-9]{10,35}"    # regex: prefix → regexify generator
+aliases:
+  beerstyle: beer_style
+```
+Then a structure can use `datatype: beer_style` or `datatype: iso_msg_id`.
+
+## Bootstrap from an existing schema — `inspect`
+
+Turn an existing schema into structure YAML instead of hand-writing it. One structure file per
+object/table/message; nesting (`$ref`, arrays, FKs) is mapped to `object[...]` / `array[...]` /
+`ref[...]`.
+
+```bash
+./seedstream inspect <file> --output config/structures/ [--force]
+```
+
+**Sources** (auto-detected from extension/content; override with `--format`):
+
+| Source | Extensions / detection | Notes |
+|---|---|---|
+| OpenAPI 3.x | `.yaml`/`.yml`/`.json` with `openapi`/`swagger` root | schemas under `components.schemas` |
+| JSON Schema | `.schema.json`, or `.json`/`.yaml` with `$schema`/`$defs`/`definitions` root | root object + `$defs`/`definitions`; `allOf`/`oneOf`/etc. merged into one record |
+| SQL DDL | `.sql` | `CREATE TABLE`; FKs → `ref[...]`; `--nest` inverts 1:n/1:1 to nested objects |
+| Protobuf | `.desc`/`.binpb`/`.protoset` (compiled FileDescriptorSet) | pre-compile `.proto` via `protoc --descriptor_set_out` / `buf build -o` |
+
+`--format openapi|jsonschema|ddl|protobuf` forces the source when detection is ambiguous.
+
+**Review workflow**: inspect emits best guesses and marks uncertain ones with inline
+`# review: …` / `# guessed from column name — verify` comments plus a run-summary warning count.
+Always tell the user to skim the flagged fields before generating. Existing files are **skipped**
+(not clobbered) unless `--force`.
+
+**Regex fields (`pattern`) — the faker-types loop**: JSON Schema `string` + `pattern` has no inline
+type, so inspect writes a companion `inspect-faker-types.yaml` (in `--output`) with a `regex:` entry
+per field, and comments the field. Feed it back to resolve those fields:
+```bash
+./seedstream inspect payload.schema.json -o config/structures/            # writes inspect-faker-types.yaml
+./seedstream inspect payload.schema.json -o config/structures/ --force \
+    --faker-types config/structures/inspect-faker-types.yaml              # fields now use the regex type
+./seedstream execute --job config/jobs/<job>.yaml \
+    --faker-types config/structures/inspect-faker-types.yaml --count 100  # generate matching values
+```
+The companion file is never overwritten if it exists, and never written over the `--faker-types`
+input.
+
+**Inspect flags**: `--output <dir>`, `--force`, `--format <fmt>`, `--faker-types <file>`,
+`--best-effort` (DDL: emit the parseable subset, warn on the rest), `--nest[=auto|all|none]` +
+`--nest-default-count <min..max>` (DDL: FK inversion). See `docs/INSPECT-V1-SPEC.md` for full detail.
 
 ## Job YAML Templates
 
@@ -73,10 +151,10 @@ type: file
 structures_path: config/structures/          # optional, this is the default
 seed:
   type: embedded
-  value: <number>                            # any long integer
+  value: <number>
 conf:
-  path: cli/output/<name>                   # extension added automatically by format flag
-  compress: false                           # true = gzip (.gz)
+  path: cli/output/<name>                     # extension added by the --format flag
+  compress: false                             # true = gzip (.gz)
   append: false
 ```
 
@@ -88,13 +166,13 @@ seed:
   type: embedded
   value: <number>
 conf:
-  bootstrap: localhost:9092                 # comma-separated brokers
+  bootstrap: localhost:9092                    # comma-separated brokers
   topic: <topic_name>
-  batch_size: 1000                          # records per batch
-  linger_ms: 10                             # ms to wait for batch fill
-  compression: gzip                         # gzip | snappy | lz4 | zstd | none
-  acks: "1"                                 # "0" | "1" | "all"
-  sync: false                               # false=async (default), true=sync
+  batch_size: 1000
+  linger_ms: 10
+  compression: gzip                            # gzip | snappy | lz4 | zstd | none
+  acks: "1"                                    # "0" | "1" | "all"
+  sync: false                                  # false=async (default), true=sync
   # Optional SASL/SSL:
   # security_protocol: SASL_SSL
   # sasl_mechanism: PLAIN
@@ -113,70 +191,57 @@ conf:
   jdbc_url: "jdbc:postgresql://localhost:5432/<db>"
   username: "<user>"
   password: "${DB_PASSWORD}"
-  table: "<table_name>"                     # optional — defaults to structure name
+  table: "<table_name>"                        # optional — defaults to structure name
   batch_size: 1000
   pool_size: 5
-  transaction_strategy: per_batch          # per_batch | per_job | auto_commit
+  transaction_strategy: per_batch              # per_batch | per_job | auto_commit
 ```
 
 ## Seed Types
 
 ```yaml
-# Embedded (most common)
-seed:
-  type: embedded
-  value: 12345
-
-# Environment variable
-seed:
-  type: env
-  name: MY_SEED_VAR
-
-# File
-seed:
-  type: file
-  path: /secrets/seed.txt
-
-# Remote API (returns {"seed": 123456789})
-seed:
+seed: {type: embedded, value: 12345}           # most common
+seed: {type: env, name: MY_SEED_VAR}           # environment variable
+seed: {type: file, path: /secrets/seed.txt}    # file
+seed:                                          # remote API returning {"seed": 123456789}
   type: remote
   url: https://seed-api.example.com/generate
-  auth:
-    type: bearer          # bearer | basic | api_key
-    token: ${SEED_API_TOKEN}
+  auth: {type: bearer, token: ${SEED_API_TOKEN}}   # bearer | basic | api_key
 ```
+Seed precedence: CLI `--seed` > job YAML > default 0 (with a warning).
 
 ## Run Commands
 
-After generating files, always print the test command:
+Use the `./seedstream` launcher (builds the fat JAR on first run; falls back to
+`./gradlew :cli:run --args="…"` only if the launcher isn't present).
 
 ```bash
-# File destination
-./gradlew :cli:run --args="execute --job config/jobs/<file>.yaml --format json --count 10"
-
-# Kafka destination (requires broker)
-./gradlew :cli:run --args="execute --job config/jobs/<file>.yaml --format json --count 100"
-
-# With seed override
-./gradlew :cli:run --args="execute --job config/jobs/<file>.yaml --seed 99999 --count 10"
-
-# With threads (high volume)
-./gradlew :cli:run --args="execute --job config/jobs/<file>.yaml --count 1000000 --threads 8"
+./seedstream execute --job config/jobs/<file>.yaml --format json --count 10
+./seedstream execute --job config/jobs/<file>.yaml --seed 99999 --count 10       # seed override
+./seedstream execute --job config/jobs/<file>.yaml --count 1000000 --threads 8   # high volume
+./seedstream execute --job config/jobs/<file>.yaml --faker-types <types>.yaml    # custom types
 ```
 
-**Formats**: `json` (newline-delimited NDJSON) | `csv` (RFC 4180, header row) | `protobuf`
+**Formats**: `json` (NDJSON) | `csv` (RFC 4180, header row) | `protobuf` | `avro` |
+`avro-registry` (Confluent Schema Registry) | `cbeff` (biometric). Default: `json`.
+
+Other subcommands (mention only if relevant): `inspect` (above), `validate` (checks a biometric
+NDJSON file), `encrypt` (AES-256 helper).
 
 ## Decision Guide
 
 | Scenario | Recommendation |
 |----------|---------------|
-| Flat, no nesting | Use primitive/semantic types only |
-| Realistic names, emails, etc. | Use Datafaker semantic types + `geolocation` |
-| Sub-documents (e.g. address inside order) | `object[address]` — create address.yaml separately |
-| Variable collections (e.g. line items) | `array[object[item], min..max]` |
-| Kafka streaming load test | batch_size ≥ 1000, lz4 compression, sync: false |
-| Reproducible test data | Set explicit `seed.value`, commit the job YAML |
-| CI/CD / secret management | `seed.type: env` with `seed.name` |
+| Small flat record (≤ ~10 primitives) | Hand-write it — faster than inspect |
+| Large / nested / constraint-rich, or schema already exists | `inspect` the source, then review flags |
+| Realistic names, emails, etc. | Datafaker semantic types + `geolocation` |
+| Sub-documents (address in order) | `object[address]` — create address.yaml too |
+| Variable collections (line items) | `array[object[item], min..max]` |
+| Cross-record reference (order → customer) | `ref[customer.id, 1..count]` |
+| Patterned string (ISO id, SKU) | `--faker-types` with a `regex:` entry |
+| Kafka streaming load test | batch_size ≥ 1000, lz4, sync: false |
+| Reproducible test data | explicit `seed.value`, commit the job YAML |
+| CI/CD secret management | `seed.type: env` with `seed.name` |
 | Database with nested objects | `type: database` + `transaction_strategy: per_batch`; tables must pre-exist |
 
 ## Geolocation Reference (62 locales)
@@ -200,79 +265,62 @@ User: "I need a product record with id, name, price, and category"
 name: product
 geolocation: usa
 data:
-  id:
-    datatype: uuid
-  name:
-    datatype: char[5..40]
-  price:
-    datatype: decimal[0.01..9999.99]
-  category:
-    datatype: enum[electronics,clothing,food,books,sports]
+  id: {datatype: uuid}
+  name: {datatype: char[5..40]}
+  price: {datatype: decimal[0.01..9999.99]}
+  category: {datatype: enum[electronics,clothing,food,books,sports]}
 ```
 
-### Nested structure
-User: "Create an order structure with customer info and items list"
-
+### Nested structure with an array
 ```yaml
 # config/structures/order_item.yaml — create first
 name: order_item
 geolocation: usa
 data:
-  product_id:
-    datatype: uuid
-  product_name:
-    datatype: char[5..40]
-  quantity:
-    datatype: int[1..50]
-  unit_price:
-    datatype: decimal[0.01..999.99]
+  product_id: {datatype: uuid}
+  product_name: {datatype: char[5..40]}
+  quantity: {datatype: int[1..50]}
+  unit_price: {datatype: decimal[0.01..999.99]}
 ```
-
 ```yaml
 # config/structures/order.yaml
 name: order
 geolocation: usa
 data:
-  order_id:
-    datatype: uuid
-    alias: "id"
-  customer_name:
-    datatype: name
-  customer_email:
-    datatype: email
-  created_at:
-    datatype: timestamp[now-90d..now]
-  status:
-    datatype: enum[pending,confirmed,shipped,delivered,cancelled]
-  items:
-    datatype: array[object[order_item], 1..15]
-  total:
-    datatype: decimal[1.00..50000.00]
+  order_id: {datatype: uuid, alias: "id"}
+  customer_name: {datatype: name}
+  customer_email: {datatype: email}
+  created_at: {datatype: timestamp[now-90d..now]}
+  status: {datatype: enum[pending,confirmed,shipped,delivered,cancelled]}
+  items: {datatype: array[object[order_item], 1..15]}
+  total: {datatype: decimal[1.00..50000.00]}
 ```
 
-### Kafka job with high throughput config
+### Foreign-key reference across structures
 ```yaml
-# config/jobs/kafka_order.yaml
-source: order.yaml
-type: kafka
-seed:
-  type: embedded
-  value: 42
-conf:
-  bootstrap: localhost:9092
-  topic: orders
-  batch_size: 5000
-  linger_ms: 5
-  compression: lz4
-  acks: "all"
-  sync: false
+# config/structures/payment.yaml
+name: payment
+geolocation: usa
+data:
+  payment_id: {datatype: uuid}
+  order_id: {datatype: ref[order.order_id, 1..count]}   # references an existing order
+  amount: {datatype: decimal[1.00..50000.00]}
+```
+
+### Bootstrap from a JSON Schema (with a regex field)
+```bash
+./seedstream inspect payload.schema.json -o config/structures/
+# → writes payload structures + inspect-faker-types.yaml for any pattern fields; review # comments
+./seedstream inspect payload.schema.json -o config/structures/ --force \
+    --faker-types config/structures/inspect-faker-types.yaml
 ```
 
 ## Boundaries
 
-- Never add fields the user didn't ask for (no extra audit columns, etc.)
-- Don't create DDL — database tables must pre-exist
-- Don't bundle JDBC drivers — tell user to drop JAR in `extras/`
-- Seed value: any long; default to a memorable number like `42` or `12345` if user doesn't specify
-- File `path` has no extension — format flag appends it at runtime
-- After writing files, validate structure names match filenames (name field = filename without .yaml)
+- Never add fields the user didn't ask for (no extra audit columns).
+- Don't create DDL — database tables must pre-exist.
+- Don't bundle JDBC drivers — tell the user to drop the JAR in `extras/`.
+- Seed value: any long; default to a memorable number (`42`, `12345`) if unspecified.
+- File `path` has no extension — the `--format` flag appends it at runtime.
+- After writing, verify `name:` matches the filename (minus `.yaml`).
+- After an `inspect`, always tell the user to review the `# review` / name-hint comments before generating.


### PR DESCRIPTION
## What

Refreshes the `.claude/skills/seedstream-config` wizard, which had drifted from the current CLI and type system (it only knew about hand-writing structures/jobs).

## Changes

- **New "Bootstrap from an existing schema" section** — all four `inspect` sources (OpenAPI / JSON Schema / SQL DDL / Protobuf), auto-detection, the review-comment workflow, and the regex `--faker-types` rerun loop.
- **Type system** — adds `ref[...]` foreign keys (range required, `1..count`) and custom `--faker-types` (dot-chain expressions + `regex:` prefix).
- **Corrected semantic types against `DatafakerRegistry`** — the old list named keys that don't exist: `ip_address` (real keys are `ipv4`/`ipv6`), `job_title` (→ `occupation`/`title`), `industry` (dropped). Replaced the vague "~80 keys" with the verified set grouped by domain, plus a "don't invent keys" guard.
- **Run commands** → `./seedstream …` launcher (was `./gradlew :cli:run --args=…`).
- **Formats** → added `avro` / `avro-registry` / `cbeff`; noted `validate` / `encrypt`.
- **`model: sonnet`** pinned — a Q&A + YAML-templating task; accurate enough and cost-predictable regardless of the caller's session model.

## Notes

Skill-only change (no product code). Complements the JSON Schema inspect feature in #197.