### PR TITLE
fix(deps): bump log4j 2.26.1 + force netty 4.1.136 to clear CVEs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,8 +101,9 @@ subprojects {
     // which OWASP DC flags even when runtimeClasspath overrides them correctly.
     configurations.all {
         resolutionStrategy.force(
-            "org.apache.logging.log4j:log4j-core:2.26.0",
-            "org.apache.logging.log4j:log4j-api:2.26.0",
+            // log4j 2.26.0 is vulnerable to CVE-2026-49844; 2.26.1 is the fix.
+            "org.apache.logging.log4j:log4j-core:2.26.1",
+            "org.apache.logging.log4j:log4j-api:2.26.1",
             // commons-lang3: compileClasspath resolves 3.14.0 (from AWS SDK transitive)
             // while runtimeClasspath correctly overrides to 3.20.0. Force 3.20.0 everywhere
             // so OWASP DC never sees 3.14.0 on any configuration.
@@ -118,6 +119,22 @@ subprojects {
             // OWASP DC never sees 2.20.0 on any configuration.
             "com.fasterxml.jackson.core:jackson-databind:2.22.1"
         )
+        // netty ships ~20 coordinated artifacts, all pulled transitively at 4.1.135.Final via
+        // software.amazon.awssdk:netty-nio-client (awssdk 2.48.3 still resolves .135). 4.1.135 is
+        // vulnerable to CVE-2026-44891, CVE-2026-55831, CVE-2026-55833; 4.1.136.Final is the fix.
+        // eachDependency force covers every io.netty artifact without listing each coordinate.
+        resolutionStrategy.eachDependency {
+            // tcnative (netty-tcnative*) and netty-bom follow their own versioning, not the
+            // 4.1.x line, and are not in the CVE set — leave them alone.
+            if (requested.group == "io.netty" &&
+                requested.name.startsWith("netty-") &&
+                !requested.name.startsWith("netty-tcnative") &&
+                requested.name != "netty-bom"
+            ) {
+                useVersion("4.1.136.Final")
+                because("CVE-2026-44891/55831/55833 — force patched netty across all configurations")
+            }
+        }
     }
 
     dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ azure-identity = "1.18.4"
 gcp-secretmanager = "2.94.0"
 
 # Security Constraints (for dependency-check)
-log4j = "2.26.0"
+log4j = "2.26.1"
 
 # Build Plugins
 jmh-plugin = "0.7.3"


### PR DESCRIPTION
Closes #206.

## What

Clears four CVEs the OWASP Dependency-Check scan (fresh NVD data) flagged:

| Dependency | CVE(s) | Fix |
|---|---|---|
| log4j 2.26.0 (direct pin) | CVE-2026-49844 | → 2.26.1 |
| netty 4.1.135.Final (transitive) | CVE-2026-44891, CVE-2026-55831, CVE-2026-55833 | force → 4.1.136.Final |

netty comes in via `software.amazon.awssdk:netty-nio-client` (awssdk 2.48.3 still resolves 4.1.135). awssdk is a **production** dependency in `:destinations` (secret backends), so netty ships in the fat JAR — the scan attributed it to `benchmarks` only because that module's classpath aggregates everything.

## How

- Bump the `log4j` catalog version and the existing `resolutionStrategy.force(...)` literals in root `build.gradle.kts` to `2.26.1`.
- Add an `eachDependency` force pinning the `io.netty` 4.1.x artifacts to `4.1.136.Final` across **all** configurations — same "force everywhere so OWASP never sees the vulnerable version on any config" pattern already used for commons-lang3 / httpcore5-h2 / jackson-databind. `netty-tcnative*` and `netty-bom` are excluded (separate versioning, not in the CVE set).

## Verification

- No unforced `4.1.135.Final` remains on any configuration (`benchmarks` / `destinations` / `cli` all resolve `→ 4.1.136.Final`); log4j resolves `2.26.1` everywhere.
- `./gradlew build test spotlessCheck` — green.
- The OWASP re-scan on CI is the authoritative gate; the four CVEs should no longer appear.