### PR TITLE
fix(generators): bic honours geolocation; add locale_currency (Closes #177)

### DIFF
--- a/core/src/main/java/com/datagenerator/core/registry/DatafakerRegistry.java
+++ b/core/src/main/java/com/datagenerator/core/registry/DatafakerRegistry.java
@@ -23,6 +23,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Currency;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
@@ -150,9 +151,11 @@ public class DatafakerRegistry {
     registerAlias("random_locale_iban", "random_iban");
     register("sepa_iban", DatafakerRegistry::sepaIban);
     register("currency", (faker, random) -> faker.money().currencyCode());
+    register("locale_currency", (faker, random) -> localeCurrency(faker));
     register("price", (faker, random) -> faker.commerce().price());
-    register("bic", (faker, random) -> conformantBic(faker));
+    register("bic", (faker, random) -> localeAwareBic(faker));
     registerAlias("swift", "bic");
+    register("random_bic", (faker, random) -> randomBic(faker));
     register("cvv", (faker, random) -> String.valueOf(faker.number().numberBetween(100, 999)));
     registerAlias("cvc", "cvv");
     register("credit_card_type", (faker, random) -> faker.finance().creditCard().split(" ")[0]);
@@ -198,19 +201,62 @@ public class DatafakerRegistry {
   }
 
   /**
-   * Generates an ISO 9362-conformant BIC. A BIC must be uppercase letters and digits only.
+   * Generates an ISO 9362-conformant BIC from a random country, ignoring the Faker locale. A BIC
+   * must be uppercase letters and digits only.
    *
    * <p>Datafaker's {@code Finance.bic()} interpolates the ISO 3166-1 alpha-2 country code
    * (positions 5-6) from locale YAML, where it is stored lowercase, producing non-conformant BICs
    * such as {@code "UFMNmzAVSDD"}. We normalize to uppercase here. This is the correct
    * normalization per ISO 9362 regardless of upstream behavior and is idempotent, so it remains
-   * safe if Datafaker fixes the casing.
+   * safe if Datafaker fixes the casing. The country is whatever Datafaker picked
+   * (locale-insensitive) — the {@code bic} type derives the country from the locale instead; use
+   * {@code random_bic} to keep this behavior.
    *
    * <p>Upstream:
    * https://github.com/datafaker-net/datafaker/commit/d4267942d61314017cba303f98cd607d071409f4
    */
-  private static String conformantBic(Faker faker) {
+  private static String randomBic(Faker faker) {
     return faker.finance().bic().toUpperCase(Locale.ROOT);
+  }
+
+  /**
+   * Generates a BIC whose ISO 3166-1 country (positions 5-6) matches the Faker locale, so {@code
+   * geolocation: italy} yields an {@code ....IT..} BIC consistent with the locale-aware
+   * name/address/IBAN.
+   *
+   * <p>Datafaker's {@code Finance.bic()} does not honor the locale for the country segment (see
+   * #177), so we splice the locale country into positions 5-6 of an otherwise-conformant BIC. Falls
+   * back to {@link #randomBic} when the locale carries no 2-letter country (language-only locale)
+   * or the generated BIC is too short to carry a country segment.
+   */
+  private static String localeAwareBic(Faker faker) {
+    String bic = randomBic(faker);
+    String country = faker.getContext().getLocale().getCountry().toUpperCase(Locale.ROOT);
+    if (country.length() != 2 || bic.length() < 6) {
+      return bic;
+    }
+    return bic.substring(0, 4) + country + bic.substring(6);
+  }
+
+  /**
+   * Returns the ISO 4217 currency code for the Faker locale's country, so {@code geolocation:
+   * italy} yields {@code EUR} and {@code usa} yields {@code USD}. Unlike {@code currency} (a random
+   * ISO 4217 code — a system may transact many currencies), this ties the currency to the locale.
+   *
+   * <p>Uses the JDK's {@link Currency#getInstance(Locale)}. Falls back to a random {@code currency}
+   * when the locale has no country or the JDK has no currency for it (e.g. a language-only locale
+   * or a territory with no legal tender).
+   */
+  private static String localeCurrency(Faker faker) {
+    Locale locale = faker.getContext().getLocale();
+    if (!locale.getCountry().isBlank()) {
+      try {
+        return Currency.getInstance(locale).getCurrencyCode();
+      } catch (IllegalArgumentException e) {
+        log.debug("No currency for locale {}, falling back to random currency", locale, e);
+      }
+    }
+    return faker.money().currencyCode();
   }
 
   /**

--- a/core/src/test/java/com/datagenerator/core/registry/DatafakerRegistryTest.java
+++ b/core/src/test/java/com/datagenerator/core/registry/DatafakerRegistryTest.java
@@ -251,8 +251,10 @@ class DatafakerRegistryTest {
     assertThat(DatafakerRegistry.generate("random_iban", FAKER, RANDOM)).isNotBlank();
     assertThat(DatafakerRegistry.generate("sepa_iban", FAKER, RANDOM)).isNotBlank();
     assertThat(DatafakerRegistry.generate("currency", FAKER, RANDOM)).isNotBlank();
+    assertThat(DatafakerRegistry.generate("locale_currency", FAKER, RANDOM)).isNotBlank();
     assertThat(DatafakerRegistry.generate("price", FAKER, RANDOM)).isNotBlank();
     assertThat(DatafakerRegistry.generate("bic", FAKER, RANDOM)).isNotBlank();
+    assertThat(DatafakerRegistry.generate("random_bic", FAKER, RANDOM)).isNotBlank();
     assertThat(DatafakerRegistry.generate("cvv", FAKER, RANDOM)).isNotBlank();
     assertThat(DatafakerRegistry.generate("credit_card_type", FAKER, RANDOM)).isNotBlank();
     assertThat(DatafakerRegistry.generate("stock_market", FAKER, RANDOM)).isNotBlank();

--- a/docs/DATAFAKER-COVERAGE.md
+++ b/docs/DATAFAKER-COVERAGE.md
@@ -59,9 +59,11 @@ Aliases are case-insensitive and normalized at lookup time.
 | `iban` | `faker.finance().iban(country)` — locale-aware: uses the locale's country when Datafaker supports it, else random-country | — |
 | `random_iban` | `faker.finance().iban()` — explicit random-country IBAN (e.g. cross-border destination accounts) | `random_locale_iban` |
 | `sepa_iban` | `faker.finance().iban(country)` for a random **SEPA-zone** country — locale-independent | — |
-| `currency` | `faker.money().currencyCode()` | — |
+| `currency` | `faker.money().currencyCode()` — random ISO 4217 (a system may transact many currencies) | — |
+| `locale_currency` | `Currency.getInstance(locale)` — ISO 4217 for the locale's country (e.g. `italy`→EUR, `usa`→USD); falls back to random when the locale has no country/currency | — |
 | `price` | `faker.commerce().price()` | — |
-| `bic` | `faker.finance().bic()` | `swift` |
+| `bic` | `faker.finance().bic()` with the locale country spliced into positions 5-6 — locale-aware (see #177), uppercased per ISO 9362 | `swift` |
+| `random_bic` | `faker.finance().bic()` — random-country BIC (pre-#177 behavior), uppercased | — |
 | `cvv` | `faker.number().numberBetween(100, 999)` | `cvc` |
 | `credit_card_type` | `faker.finance().creditCard().split(" ")[0]` | `creditcardtype` |
 | `stock_market` | `faker.stock().nsdqSymbol()` | `stockmarket`, `stock`, `ticker` |

--- a/generators/src/main/java/com/datagenerator/generators/package-info.java
+++ b/generators/src/main/java/com/datagenerator/generators/package-info.java
@@ -59,8 +59,8 @@
  *   <li><b>Primitives:</b> char, int, decimal, boolean, date, timestamp
  *   <li><b>Semantic:</b> name, first_name, last_name, full_name, username, title, occupation,
  *       address, street_name, street_number, city, state, postal_code, country, email,
- *       phone_number, company, credit_card, iban, currency, price, domain, url, ipv4, ipv6,
- *       mac_address, isbn, uuid
+ *       phone_number, company, credit_card, iban, bic, currency, locale_currency, price, domain,
+ *       url, ipv4, ipv6, mac_address, isbn, uuid
  *   <li><b>Enums:</b> Predefined value lists
  *   <li><b>Arrays:</b> Variable-length collections with inner type
  *   <li><b>Objects:</b> Nested structure references

--- a/generators/src/main/java/com/datagenerator/generators/semantic/package-info.java
+++ b/generators/src/main/java/com/datagenerator/generators/semantic/package-info.java
@@ -34,7 +34,7 @@
  *   <li><b>Person:</b> name, first_name, last_name, full_name, username, title, occupation
  *   <li><b>Address:</b> address, street_name, street_number, city, state, postal_code, country
  *   <li><b>Contact:</b> email, phone_number
- *   <li><b>Finance:</b> company, credit_card, iban, currency, price
+ *   <li><b>Finance:</b> company, credit_card, iban, bic, currency, locale_currency, price
  *   <li><b>Internet:</b> domain, url, ipv4, ipv6, mac_address
  *   <li><b>Codes:</b> isbn, uuid
  * </ul>

--- a/generators/src/test/java/com/datagenerator/generators/semantic/DatafakerGeolocationTest.java
+++ b/generators/src/test/java/com/datagenerator/generators/semantic/DatafakerGeolocationTest.java
@@ -175,6 +175,41 @@ class DatafakerGeolocationTest {
     assertThat(countries).isSubsetOf(SEPA_COUNTRIES).hasSizeGreaterThan(1);
   }
 
+  // BIC: 8 or 11 uppercase alphanumerics; country in positions 5-6 (0-based index 4-5).
+  private static final String BIC_PATTERN = "^[A-Z0-9]{8}([A-Z0-9]{3})?$";
+
+  @ParameterizedTest
+  @CsvSource({"italy, IT", "germany, DE", "france, FR", "usa, US"})
+  void shouldGenerateBicForLocaleCountry(String geolocation, String expectedCountry) {
+    // #177: bic must carry the locale country in positions 5-6, not a random one.
+    String bic = (String) generateWithContext(geolocation, new CustomDatafakerType("bic"));
+    assertThat(bic).isNotNull().matches(BIC_PATTERN);
+    assertThat(bic.substring(4, 6)).isEqualTo(expectedCountry);
+  }
+
+  @Test
+  void shouldGenerateRandomBicIndependentOfLocale() {
+    String bic = (String) generateWithContext("italy", new CustomDatafakerType("random_bic"));
+    assertThat(bic).isNotNull().matches(BIC_PATTERN);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"italy, EUR", "germany, EUR", "usa, USD", "uk, GBP", "japan, JPY"})
+  void shouldGenerateLocaleCurrencyForLocaleCountry(String geolocation, String expectedCurrency) {
+    // #177: locale_currency ties the ISO 4217 code to the locale country.
+    String currency =
+        (String) generateWithContext(geolocation, new CustomDatafakerType("locale_currency"));
+    assertThat(currency).isEqualTo(expectedCurrency);
+  }
+
+  @Test
+  void shouldKeepCurrencyLocaleInsensitive() {
+    // currency stays a random ISO 4217 code (a system may transact many currencies), so italy
+    // is not pinned to EUR — that's what locale_currency is for.
+    String currency = (String) generateWithContext("italy", new CustomDatafakerType("currency"));
+    assertThat(currency).isNotNull().matches("^[A-Z]{3}$");
+  }
+
   // ==================================================================================
   // ALL SEMANTIC TYPES COVERAGE - Test every semantic type we support
   // ==================================================================================


### PR DESCRIPTION
## Summary
`bic` and `currency` ignored the structure's `geolocation` (#177). Only `iban` was fixed (#173). This closes the gap.

- **`bic`** → locale-aware: splices the faker-locale ISO country into BIC positions 5-6, uppercased (ISO 9362). **Behaviour change** — existing `bic` configs now emit a locale-country BIC instead of a random one.
- **`random_bic`** (new) → preserves the previous random-country BIC (mirrors `random_iban`) as an escape hatch.
- **`locale_currency`** (new) → `java.util.Currency.getInstance(locale)` — `italy`→EUR, `usa`→USD; falls back to random currency on language-only locales.
- **`currency`** → unchanged (random ISO 4217; a system may legitimately transact many currencies — the issue's own note).

No cross-module work: the registry function already receives the locale-carrying `faker` (`faker.getContext().getLocale()`), same access `localeAwareIban` uses.

## Test
- `DatafakerGeolocationTest`: BIC country splice per locale (IT/DE/FR/US), `random_bic` valid, `locale_currency` EUR/USD/GBP/JPY, `currency` stays random.
- `DatafakerRegistryTest`: `locale_currency` + `random_bic` registered.
- Homelab sonar gate: PASS, 0 new-code blocker/critical.

## Docs
`DATAFAKER-COVERAGE.md` finance table + two package-info type lists.

Closes #177