### PR TITLE
feat(destinations): opt-in table truncation for CI reseeding (Closes #80)

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,6 @@
+---
+# SQL files here are database DDL/fixtures, not application code. Codacy applies a
+# SQL Server (T-SQL) linter that misfires on PostgreSQL syntax (e.g. demanding
+# SET QUOTED_IDENTIFIER), so exclude them from analysis.
+exclude_paths:
+  - 'config/sql/**'

--- a/cli/src/main/java/com/datagenerator/cli/ExecuteCommand.java
+++ b/cli/src/main/java/com/datagenerator/cli/ExecuteCommand.java
@@ -779,6 +779,9 @@ public class ExecuteCommand implements Callable<Integer> {
     if (conf.has("inject_parent_fk")) {
       builder.injectParentFk(conf.get("inject_parent_fk").asBoolean());
     }
+    if (conf.has("truncate_before_insert")) {
+      builder.truncateBeforeInsert(conf.get("truncate_before_insert").asBoolean());
+    }
 
     DatabaseDestinationConfig dbConfig = builder.build();
     log.info(

--- a/config/README.md
+++ b/config/README.md
@@ -789,7 +789,13 @@ conf:
   batch_size: 1000
   pool_size: 5
   transaction_strategy: per_batch  # per_batch | per_job | auto_commit
+  truncate_before_insert: false    # ⚠️ DESTRUCTIVE — see "CI seeding" below
 ```
+
+**CI seeding (`truncate_before_insert`)**: Set to `true` to empty each target table with `TRUNCATE TABLE ... CASCADE` before its first insert. Combined with a fixed `seed`, one `execute` gives a clean, deterministic dataset per run — no external teardown script. Defaults to `false`. Notes:
+- ⚠️ **Destructive** — wipes the table (and, via `CASCADE`, its FK dependents). Use only against a disposable/CI database.
+- Tables must already exist (no DDL). CASCADE clears nested child tables in one shot, so FK graphs reseed cleanly.
+- PostgreSQL/Oracle only — `CASCADE` is not valid MySQL/SQL Server `TRUNCATE` syntax.
 
 **Nested structures (Stage 2)**: When a structure contains `object[X]` or `array[object[X]]` fields, SeedStream automatically decomposes the tree into multi-table INSERTs. The parent is inserted first; each child gets a `{parent_table}_id` FK column injected automatically.
 

--- a/config/jobs/db_ci_seed_users.yaml
+++ b/config/jobs/db_ci_seed_users.yaml
@@ -1,0 +1,26 @@
+# CI pipeline database seeding (issue #80).
+#
+# Run this BEFORE the integration-test task. The fixed seed makes the dataset
+# byte-for-byte identical on every run and every branch, so test assertions can
+# reference specific generated values with confidence. `truncate_before_insert`
+# empties the table first (TRUNCATE ... CASCADE) — each run reseeds from clean,
+# eliminating "test depends on pre-existing state" flakiness.
+#
+# Example:
+#   export DB_PASSWORD=...
+#   psql -f config/sql/ci_seed_users.sql          # one-time: create the table
+#   ./seedstream execute --job config/jobs/db_ci_seed_users.yaml --count 100
+#   ./gradlew integrationTest                     # assertions see the same 100 rows
+source: ci_user.yaml
+type: database
+seed:
+  type: embedded
+  value: 424242          # fixed — do NOT change between runs; it defines the dataset
+conf:
+  jdbc_url: "jdbc:postgresql://localhost:5432/testdb"
+  username: "dbuser"
+  password: "${DB_PASSWORD}"
+  table: "ci_users"
+  batch_size: 1000
+  transaction_strategy: per_batch
+  truncate_before_insert: true   # ⚠️ DESTRUCTIVE — reseed clean; disposable/CI DB only

--- a/config/sql/ci_seed_users.sql
+++ b/config/sql/ci_seed_users.sql
@@ -1,0 +1,16 @@
+-- CI integration-test user table (issue #80).
+-- One-time setup: creates the table SeedStream seeds via db_ci_seed_users.yaml.
+-- The job's `truncate_before_insert: true` empties this table on every run, so
+-- this script only needs to run once (or whenever the schema changes).
+--
+-- Usage: psql -U dbuser -d testdb -f ci_seed_users.sql
+
+CREATE TABLE IF NOT EXISTS ci_users (
+  id          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  first_name  VARCHAR(255) NOT NULL,
+  last_name   VARCHAR(255) NOT NULL,
+  email       VARCHAR(255) NOT NULL,
+  username    VARCHAR(255) NOT NULL,
+  active      BOOLEAN      NOT NULL,
+  signup_date DATE         NOT NULL
+);

--- a/config/structures/ci_user.yaml
+++ b/config/structures/ci_user.yaml
@@ -1,0 +1,18 @@
+# CI integration-test user fixture.
+# Flat structure — one row per generated record maps 1:1 to a `ci_users` row.
+# The DB assigns the primary key (identity column), so no `id` field is generated here.
+name: ci_user
+geolocation: usa
+data:
+  first_name:
+    datatype: first_name
+  last_name:
+    datatype: last_name
+  email:
+    datatype: email
+  username:
+    datatype: username
+  active:
+    datatype: boolean
+  signup_date:
+    datatype: date[2020-01-01..2024-12-31]

--- a/destinations/src/main/java/com/datagenerator/destinations/database/DatabaseDestination.java
+++ b/destinations/src/main/java/com/datagenerator/destinations/database/DatabaseDestination.java
@@ -27,12 +27,15 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
@@ -150,6 +153,13 @@ public class DatabaseDestination extends AbstractDestination {
 
   // --- Common state ---
   private long totalInserted = 0;
+
+  /**
+   * Tables already truncated in this run. Guards {@link #truncateIfNeeded(String)} so each table is
+   * emptied at most once, before its first insert. Only populated when {@code
+   * truncate_before_insert} is enabled.
+   */
+  private final Set<String> truncatedTables = new HashSet<>();
 
   /**
    * Create a database destination with the given configuration (Option A — no schema).
@@ -365,6 +375,7 @@ public class DatabaseDestination extends AbstractDestination {
           "Table name and column names are validated by validateIdentifier(); "
               + "any identifier with non-alphanumeric/underscore chars is rejected before reaching this point")
   private void initializeStatement(Map<String, Object> firstRecord) {
+    truncateIfNeeded(config.getTableName());
     columnNames = new ArrayList<>(firstRecord.keySet());
     String sql = buildInsertSql(config.getTableName(), columnNames);
     try {
@@ -478,6 +489,7 @@ public class DatabaseDestination extends AbstractDestination {
               + "PreparedStatement is stored in nestedStatements immediately after creation — "
               + "no resource leak path exists")
   private void initNestedStatementIfAbsent(String tableName, Map<String, Object> firstRecord) {
+    truncateIfNeeded(tableName);
     if (nestedStatements.containsKey(tableName)) return;
 
     List<String> cols = new ArrayList<>(firstRecord.keySet());
@@ -513,6 +525,35 @@ public class DatabaseDestination extends AbstractDestination {
               + "'");
     }
     return name;
+  }
+
+  /**
+   * Empties {@code tableName} with {@code TRUNCATE TABLE ... CASCADE} before its first insert, when
+   * {@code truncate_before_insert} is enabled. Idempotent per run via {@link #truncatedTables}.
+   *
+   * <p>CASCADE clears foreign-key dependents in one statement, so truncating a parent before its
+   * children (the insert order) does not violate FK constraints. TRUNCATE participates in the
+   * active transaction on PostgreSQL, so it is committed/rolled back with the surrounding batch.
+   */
+  @SuppressWarnings({"SqlSourceToSinkFlow", "java:S2077"})
+  @SuppressFBWarnings(
+      value = "SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE",
+      justification =
+          "Table name is validated by validateIdentifier(); any identifier with "
+              + "non-alphanumeric/underscore chars is rejected before reaching this point")
+  private void truncateIfNeeded(String tableName) {
+    if (!config.isTruncateBeforeInsert() || truncatedTables.contains(tableName)) {
+      return;
+    }
+    String safeTable = validateIdentifier(tableName);
+    String sql = "TRUNCATE TABLE " + safeTable + " CASCADE";
+    try (Statement st = connection.createStatement()) {
+      st.executeUpdate(sql); // nosemgrep
+      truncatedTables.add(tableName);
+      log.warn("Truncated table '{}' before insert (truncate_before_insert=true)", tableName);
+    } catch (SQLException e) {
+      throw new DestinationException("Failed to truncate table: " + tableName, e);
+    }
   }
 
   private static String buildInsertSql(String tableName, List<String> columns) {

--- a/destinations/src/main/java/com/datagenerator/destinations/database/DatabaseDestinationConfig.java
+++ b/destinations/src/main/java/com/datagenerator/destinations/database/DatabaseDestinationConfig.java
@@ -35,6 +35,7 @@ import lombok.Value;
  *   batch_size: 1000
  *   pool_size: 10
  *   transaction_strategy: per_batch
+ *   truncate_before_insert: true # DESTRUCTIVE — empties the table (CASCADE) before seeding
  * </pre>
  *
  * <p><b>Environment variable substitution:</b> String values matching {@code ${VAR_NAME}} are
@@ -103,4 +104,15 @@ public class DatabaseDestinationConfig {
    * column.
    */
   @Builder.Default boolean injectParentFk = true;
+
+  /**
+   * When {@code true}, each target table is emptied with {@code TRUNCATE TABLE ... CASCADE} before
+   * its first insert. Default: {@code false}.
+   *
+   * <p><b>DESTRUCTIVE</b> — intended for CI seeding into a disposable database, where a fixed seed
+   * plus a clean table yields a deterministic dataset without an external teardown script. The
+   * table must already exist (no DDL generation). Uses PostgreSQL/Oracle {@code CASCADE} syntax, so
+   * nested foreign-key graphs are cleared in one shot; MySQL/SQL Server are not supported.
+   */
+  @Builder.Default boolean truncateBeforeInsert = false;
 }

--- a/destinations/src/test/java/com/datagenerator/destinations/database/DatabaseDestinationTest.java
+++ b/destinations/src/test/java/com/datagenerator/destinations/database/DatabaseDestinationTest.java
@@ -17,14 +17,18 @@
 package com.datagenerator.destinations.database;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.datagenerator.destinations.DestinationException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -463,6 +467,77 @@ class DatabaseDestinationTest {
         .hasMessageContaining("failed after 2 attempt");
 
     verify(mockDs, times(2)).getConnection();
+  }
+
+  // --- truncate_before_insert (mocked JDBC: H2 does not accept TRUNCATE ... CASCADE) ---
+
+  private DatabaseDestinationConfig truncateConfig(boolean truncate) {
+    return DatabaseDestinationConfig.builder()
+        .jdbcUrl("jdbc:irrelevant")
+        .username("u")
+        .password("p")
+        .tableName(TABLE_USERS)
+        .transactionStrategy("auto_commit")
+        .truncateBeforeInsert(truncate)
+        .build();
+  }
+
+  @Test
+  @SuppressFBWarnings("SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING") // mock stub
+  void shouldTruncateTableBeforeInsertWhenEnabled() throws Exception {
+    Connection mockConn = mock(Connection.class);
+    DataSource mockDs = mock(DataSource.class);
+    Statement mockTruncateStmt = mock(Statement.class);
+    when(mockDs.getConnection()).thenReturn(mockConn);
+    when(mockConn.createStatement()).thenReturn(mockTruncateStmt);
+    when(mockConn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+
+    try (DatabaseDestination dest = new DatabaseDestination(truncateConfig(true), mockDs)) {
+      dest.open();
+      dest.write(buildRecord(1, NAME_ALICE, true));
+      dest.flush();
+    }
+
+    verify(mockTruncateStmt).executeUpdate("TRUNCATE TABLE users CASCADE");
+  }
+
+  @Test
+  @SuppressFBWarnings("SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING") // mock stub
+  void shouldNotTruncateWhenDisabled() throws Exception {
+    Connection mockConn = mock(Connection.class);
+    DataSource mockDs = mock(DataSource.class);
+    when(mockDs.getConnection()).thenReturn(mockConn);
+    when(mockConn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+
+    try (DatabaseDestination dest = new DatabaseDestination(truncateConfig(false), mockDs)) {
+      dest.open();
+      dest.write(buildRecord(1, NAME_ALICE, true));
+      dest.flush();
+    }
+
+    // createStatement() is only used by the truncate path
+    verify(mockConn, never()).createStatement();
+  }
+
+  @Test
+  @SuppressFBWarnings("SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING") // mock stub
+  void shouldTruncateOncePerTableAcrossManyRecords() throws Exception {
+    Connection mockConn = mock(Connection.class);
+    DataSource mockDs = mock(DataSource.class);
+    Statement mockTruncateStmt = mock(Statement.class);
+    when(mockDs.getConnection()).thenReturn(mockConn);
+    when(mockConn.createStatement()).thenReturn(mockTruncateStmt);
+    when(mockConn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+
+    try (DatabaseDestination dest = new DatabaseDestination(truncateConfig(true), mockDs)) {
+      dest.open();
+      for (int i = 1; i <= 5; i++) {
+        dest.write(buildRecord(i, USER_PREFIX + i, true));
+      }
+      dest.flush();
+    }
+
+    verify(mockTruncateStmt, times(1)).executeUpdate("TRUNCATE TABLE users CASCADE");
   }
 
   // --- Helpers ---

--- a/destinations/src/test/java/com/datagenerator/destinations/database/DatabaseTruncatePostgresIT.java
+++ b/destinations/src/test/java/com/datagenerator/destinations/database/DatabaseTruncatePostgresIT.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 Marco Ferretti
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datagenerator.destinations.database;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.datagenerator.destinations.IntegrationTest;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+/**
+ * PostgreSQL-only integration tests for {@code truncate_before_insert}.
+ *
+ * <p>Kept separate from {@link AbstractDatabaseDestinationIT} (which runs across all four DBs)
+ * because the feature emits {@code TRUNCATE TABLE ... CASCADE}, which is PostgreSQL/Oracle syntax.
+ * MySQL and SQL Server are intentionally out of scope for this feature.
+ */
+class DatabaseTruncatePostgresIT extends IntegrationTest {
+
+  private static final String TABLE_ORDERS = "orders";
+  private static final String TABLE_LINES = "order_lines";
+
+  @Container
+  static PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>("postgres:16-alpine")
+          .withDatabaseName("testdb")
+          .withUsername("testuser")
+          .withPassword("testpass");
+
+  private Connection verifyConnection;
+
+  @BeforeEach
+  void setUp() throws SQLException {
+    verifyConnection =
+        DriverManager.getConnection(
+            postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+    try (Statement st = verifyConnection.createStatement()) {
+      st.execute("CREATE TABLE orders (id INT PRIMARY KEY, customer VARCHAR(255))");
+      st.execute(
+          "CREATE TABLE order_lines ("
+              + "id INT, sku VARCHAR(255), orders_id INT REFERENCES orders(id))");
+    }
+  }
+
+  @AfterEach
+  void tearDown() throws SQLException {
+    try (Statement st = verifyConnection.createStatement()) {
+      st.execute("DROP TABLE IF EXISTS order_lines");
+      st.execute("DROP TABLE IF EXISTS orders");
+    }
+    verifyConnection.close();
+  }
+
+  private DatabaseDestinationConfig config(String table, boolean truncate) {
+    return DatabaseDestinationConfig.builder()
+        .jdbcUrl(postgres.getJdbcUrl())
+        .username(postgres.getUsername())
+        .password(postgres.getPassword())
+        .tableName(table)
+        .truncateBeforeInsert(truncate)
+        .build();
+  }
+
+  private Map<String, Object> order(int id, String customer) {
+    Map<String, Object> data = new LinkedHashMap<>();
+    data.put("id", id);
+    data.put("customer", customer);
+    return data;
+  }
+
+  private int count(String table) throws SQLException {
+    try (Statement st = verifyConnection.createStatement();
+        ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM " + table)) {
+      rs.next();
+      return rs.getInt(1);
+    }
+  }
+
+  @Test
+  void shouldReplaceExistingRowsWhenTruncateEnabled() throws SQLException {
+    try (Statement st = verifyConnection.createStatement()) {
+      st.execute("INSERT INTO orders (id, customer) VALUES (99, 'stale')");
+    }
+    assertThat(count(TABLE_ORDERS)).isEqualTo(1);
+
+    try (DatabaseDestination dest = new DatabaseDestination(config(TABLE_ORDERS, true))) {
+      dest.open();
+      dest.write(order(1, "Alice"));
+      dest.write(order(2, "Bob"));
+      dest.flush();
+    }
+
+    // Stale row gone; only the two fresh rows remain
+    assertThat(count(TABLE_ORDERS)).isEqualTo(2);
+    try (Statement st = verifyConnection.createStatement();
+        ResultSet rs = st.executeQuery("SELECT customer FROM orders WHERE id = 1")) {
+      assertThat(rs.next()).isTrue();
+      assertThat(rs.getString("customer")).isEqualTo("Alice");
+    }
+  }
+
+  @Test
+  void shouldKeepExistingRowsWhenTruncateDisabled() throws SQLException {
+    try (Statement st = verifyConnection.createStatement()) {
+      st.execute("INSERT INTO orders (id, customer) VALUES (99, 'stale')");
+    }
+
+    try (DatabaseDestination dest = new DatabaseDestination(config(TABLE_ORDERS, false))) {
+      dest.open();
+      dest.write(order(1, "Alice"));
+      dest.flush();
+    }
+
+    // Existing row survives — append semantics
+    assertThat(count(TABLE_ORDERS)).isEqualTo(2);
+  }
+
+  @Test
+  void shouldCascadeTruncateNestedFkChildTables() throws SQLException {
+    // Pre-populate parent + FK child with stale data
+    try (Statement st = verifyConnection.createStatement()) {
+      st.execute("INSERT INTO orders (id, customer) VALUES (99, 'stale')");
+      st.execute("INSERT INTO order_lines (id, sku, orders_id) VALUES (5, 'OLD', 99)");
+    }
+    assertThat(count(TABLE_LINES)).isEqualTo(1);
+
+    // Nested record → orders row + order_lines child row; CASCADE must clear the stale child
+    Map<String, Object> line = new LinkedHashMap<>();
+    line.put("id", 10);
+    line.put("sku", "NEW");
+    Map<String, Object> nested = new LinkedHashMap<>();
+    nested.put("id", 1);
+    nested.put("customer", "Alice");
+    nested.put(TABLE_LINES, line);
+
+    try (DatabaseDestination dest = new DatabaseDestination(config(TABLE_ORDERS, true))) {
+      dest.open();
+      dest.write(nested);
+      dest.flush();
+    }
+
+    assertThat(count(TABLE_ORDERS)).isEqualTo(1);
+    assertThat(count(TABLE_LINES)).isEqualTo(1);
+    try (Statement st = verifyConnection.createStatement();
+        ResultSet rs = st.executeQuery("SELECT sku FROM order_lines")) {
+      assertThat(rs.next()).isTrue();
+      assertThat(rs.getString("sku")).isEqualTo("NEW");
+    }
+  }
+}

--- a/destinations/src/test/java/com/datagenerator/destinations/database/DatabaseTruncatePostgresIT.java
+++ b/destinations/src/test/java/com/datagenerator/destinations/database/DatabaseTruncatePostgresIT.java
@@ -92,9 +92,17 @@ class DatabaseTruncatePostgresIT extends IntegrationTest {
     return data;
   }
 
-  private int count(String table) throws SQLException {
+  private int countOrders() throws SQLException {
     try (Statement st = verifyConnection.createStatement();
-        ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM " + table)) {
+        ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM orders")) {
+      rs.next();
+      return rs.getInt(1);
+    }
+  }
+
+  private int countOrderLines() throws SQLException {
+    try (Statement st = verifyConnection.createStatement();
+        ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM order_lines")) {
       rs.next();
       return rs.getInt(1);
     }
@@ -105,7 +113,7 @@ class DatabaseTruncatePostgresIT extends IntegrationTest {
     try (Statement st = verifyConnection.createStatement()) {
       st.execute("INSERT INTO orders (id, customer) VALUES (99, 'stale')");
     }
-    assertThat(count(TABLE_ORDERS)).isEqualTo(1);
+    assertThat(countOrders()).isEqualTo(1);
 
     try (DatabaseDestination dest = new DatabaseDestination(config(TABLE_ORDERS, true))) {
       dest.open();
@@ -115,7 +123,7 @@ class DatabaseTruncatePostgresIT extends IntegrationTest {
     }
 
     // Stale row gone; only the two fresh rows remain
-    assertThat(count(TABLE_ORDERS)).isEqualTo(2);
+    assertThat(countOrders()).isEqualTo(2);
     try (Statement st = verifyConnection.createStatement();
         ResultSet rs = st.executeQuery("SELECT customer FROM orders WHERE id = 1")) {
       assertThat(rs.next()).isTrue();
@@ -136,7 +144,7 @@ class DatabaseTruncatePostgresIT extends IntegrationTest {
     }
 
     // Existing row survives — append semantics
-    assertThat(count(TABLE_ORDERS)).isEqualTo(2);
+    assertThat(countOrders()).isEqualTo(2);
   }
 
   @Test
@@ -146,7 +154,7 @@ class DatabaseTruncatePostgresIT extends IntegrationTest {
       st.execute("INSERT INTO orders (id, customer) VALUES (99, 'stale')");
       st.execute("INSERT INTO order_lines (id, sku, orders_id) VALUES (5, 'OLD', 99)");
     }
-    assertThat(count(TABLE_LINES)).isEqualTo(1);
+    assertThat(countOrderLines()).isEqualTo(1);
 
     // Nested record → orders row + order_lines child row; CASCADE must clear the stale child
     Map<String, Object> line = new LinkedHashMap<>();
@@ -163,8 +171,8 @@ class DatabaseTruncatePostgresIT extends IntegrationTest {
       dest.flush();
     }
 
-    assertThat(count(TABLE_ORDERS)).isEqualTo(1);
-    assertThat(count(TABLE_LINES)).isEqualTo(1);
+    assertThat(countOrders()).isEqualTo(1);
+    assertThat(countOrderLines()).isEqualTo(1);
     try (Statement st = verifyConnection.createStatement();
         ResultSet rs = st.executeQuery("SELECT sku FROM order_lines")) {
       assertThat(rs.next()).isTrue();

--- a/docs/CI-SEEDING.md
+++ b/docs/CI-SEEDING.md
@@ -1,0 +1,103 @@
+# CI Pipeline Database Seeding
+
+Seed a fresh database with **known, deterministic** data before integration tests
+run. Same seed → same rows every run → assertions can reference specific generated
+values without depending on pre-existing state. (Issue #80.)
+
+## Why
+
+- **No flaky "depends on pre-existing state" failures.** Each run reseeds from clean.
+- **Reproducible across branches and machines.** A fixed seed produces byte-for-byte
+  identical data (see the determinism guarantee in the top-level `README.md`).
+- **Assertable fixtures.** Because the dataset is fixed, tests can assert on concrete
+  rows (counts, specific usernames, date ranges).
+
+## How it works
+
+`truncate_before_insert: true` on a `database` job empties each target table with
+`TRUNCATE TABLE ... CASCADE` before its first insert, then streams the generated
+rows in. Combined with a fixed `seed`, one `execute` gives a clean, identical dataset.
+
+> ⚠️ **Destructive.** TRUNCATE (with CASCADE to FK dependents) wipes the table. Point
+> it only at a disposable/CI database. Default is `false` — nothing is truncated unless
+> you opt in. PostgreSQL/Oracle only (CASCADE syntax).
+
+## Files in this example
+
+| File | Purpose |
+|------|---------|
+| `config/structures/ci_user.yaml` | Flat user fixture (DB assigns the PK identity column) |
+| `config/jobs/db_ci_seed_users.yaml` | Database job: fixed seed `424242`, `truncate_before_insert: true` |
+| `config/sql/ci_seed_users.sql` | One-time DDL for the `ci_users` table |
+
+## Local run
+
+```bash
+export DB_PASSWORD=...
+psql -U dbuser -d testdb -f config/sql/ci_seed_users.sql   # once — create the table
+./seedstream execute --job config/jobs/db_ci_seed_users.yaml --count 100
+./gradlew integrationTest                                  # sees the same 100 rows
+```
+
+Re-running `execute` truncates and reseeds — row `id`s restart, the data columns are
+identical every time.
+
+## In a CI workflow
+
+Illustrative GitHub Actions steps (adapt to your CI). The DB is a disposable service
+container, so truncation is safe:
+
+```yaml
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: testdb
+          POSTGRES_USER: dbuser
+          POSTGRES_PASSWORD: ${{ secrets.DB_PASSWORD }}
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd="pg_isready -U dbuser" --health-interval=5s
+          --health-timeout=5s --health-retries=10
+    env:
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Create fixture schema
+        run: psql -h localhost -U dbuser -d testdb -f config/sql/ci_seed_users.sql
+        env:
+          PGPASSWORD: ${{ secrets.DB_PASSWORD }}
+
+      - name: Seed deterministic data
+        run: ./seedstream execute --job config/jobs/db_ci_seed_users.yaml --count 100
+
+      - name: Run integration tests
+        run: ./gradlew integrationTest
+```
+
+## Asserting against the seeded data
+
+With a fixed seed the dataset is stable, so integration tests can assert on it. Example
+shape (adapt to your test framework / query layer):
+
+```java
+// 100 rows were seeded, all active flag deterministic, dates within the configured range
+assertThat(userRepository.count()).isEqualTo(100);
+assertThat(userRepository.findAll())
+    .allSatisfy(u -> assertThat(u.getSignupDate())
+        .isBetween(LocalDate.parse("2020-01-01"), LocalDate.parse("2024-12-31")));
+```
+
+To pin exact values (e.g. `assertThat(result).containsKey("<username>")`), run the seed
+once, read the generated value from the DB, then hard-code it in the assertion — it will
+not change as long as the seed and structure stay fixed.
+
+## Per-suite isolation
+
+For full isolation, reseed between suites: run `execute` again (it truncates first) before
+each suite that needs a pristine table. Because the seed is fixed, every suite starts from
+the identical dataset.


### PR DESCRIPTION
## Summary
Adds an opt-in `truncate_before_insert` flag to the database destination so a single deterministic `execute` gives a clean, reproducible dataset for CI integration tests — no external teardown script. Delivers the issue #80 use case end to end.

## What changed
- **`truncate_before_insert`** on the `database` destination. When `true`, each target table is emptied with `TRUNCATE TABLE ... CASCADE` before its first insert.
  - **Opt-in**: default `false`; nothing is truncated unless explicitly requested. Runtime guard + per-table dedupe set + WARN log keep it explicit.
  - `CASCADE` clears nested FK child tables in one shot, so parent-first truncate (the insert order) stays FK-safe.
  - Keeps the "table must exist / no DDL" contract — TRUNCATE only, never DROP/CREATE. PostgreSQL/Oracle syntax; MySQL/SQL Server out of scope for now.
- Wired through the CLI job config (`conf.truncate_before_insert`).

## Use case (issue #80)
- `config/structures/ci_user.yaml` — user fixture (DB assigns PK identity)
- `config/jobs/db_ci_seed_users.yaml` — fixed seed + `truncate_before_insert: true`
- `config/sql/ci_seed_users.sql` — one-time DDL
- `docs/CI-SEEDING.md` — guide with a GitHub Actions example, assertion pattern, per-suite isolation

## Testing
- Unit tests (mocked JDBC — H2 rejects `CASCADE`): SQL emitted / not emitted / once-per-table.
- PostgreSQL Testcontainers IT: replace-rows, append-when-disabled, CASCADE reseed of an FK child table — all green.
- Generation verified deterministic (byte-identical across runs); local SonarQube gate PASS, 0 blocker/critical.

Closes #80