### PR TITLE
feat(file): opt-in parallel gzip via compress_mode: per_chunk (Closes #210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Opt-in parallel gzip via `compress_mode: per_chunk` (#210)** — file destinations now support an alternative compression strategy: each generation chunk is gzipped independently on workers and concatenated as a multi-member RFC 1952 gzip, removing compression from the writer-thread bottleneck. Decompressed output is byte-identical to `stream` mode (default), and member boundaries depend only on chunk size and record count, never thread count — so per-chunk `.gz` files are byte-identical across parallel runs for a given seed. Compressed `.gz` bytes differ between modes due to per-member dictionary boundaries; the uncompressed stream remains the hard determinism guarantee. Requires `compress: true` and an NDJSON-style format (JSON/NDJSON only; CSV/Avro unchanged). Gated on new `compress_mode` YAML key (`stream` = default, `per_chunk` = opt-in).
+
 ---
 
 ## [0.7.0] - 2026-07-14

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Determinism is abstract until you watch two hashes match. One command generates 
 
 The output byte-for-byte does not depend on thread count, core count, or machine — only the seed. This is the property that makes reproducible bug reports, golden-master pipeline tests, and "ship the recipe, not the data" collaboration possible. It's locked in CI by `GenerationEngineTest.shouldProduceIdenticalOrderedOutputRegardlessOfThreadCount`.
 
+**Compressed output (gzip):** SeedStream supports two compression modes for file destinations:
+- **`compress_mode: stream` (default)** — the entire output is gzipped as a single stream on the writer thread. The `.gz` file is a single gzip member; decompressed bytes are byte-identical to the uncompressed output. `.gz` bytes are byte-identical across thread counts and machines (same seed, same version, same JDK zlib).
+- **`compress_mode: per_chunk` (opt-in)** — each generation chunk is gzipped independently on workers as a separate gzip member, then the writer concatenates complete members in chunk order. The resulting `.gz` file is a valid multi-member gzip (RFC 1952, transparent to `gunzip` and `GZIPInputStream`). Decompressed bytes remain byte-identical to the uncompressed output (hard determinism guarantee), but compressed `.gz` bytes differ from `stream` mode and are a function of member boundaries — which depend only on `chunkSize` and record count, never thread count. Per-chunk mode moves gzip deflate off the single writer thread onto parallel workers, with a trade-off: slightly lower compression ratio (few %) due to smaller dictionaries per member, but removes compression from the writer-thread bottleneck on large jobs.
+
 ---
 
 ## Requirements

--- a/cli/src/main/java/com/datagenerator/cli/ExecuteCommand.java
+++ b/cli/src/main/java/com/datagenerator/cli/ExecuteCommand.java
@@ -667,14 +667,15 @@ public class ExecuteCommand implements Callable<Integer> {
       log.warn("Output file {} exists and will be truncated", targetPath);
     }
 
-    FileDestinationConfig config =
-        FileDestinationConfig.builder()
-            .filePath(targetPath)
-            .compress(compress)
-            .append(append)
-            .build();
+    FileDestinationConfig.FileDestinationConfigBuilder configBuilder =
+        FileDestinationConfig.builder().filePath(targetPath).compress(compress).append(append);
 
-    return new FileDestination(config, serializer);
+    // Optional compress_mode (validated fail-fast in FileDestination.open())
+    if (conf.has("compress_mode")) {
+      configBuilder.compressMode(conf.get("compress_mode").asText());
+    }
+
+    return new FileDestination(configBuilder.build(), serializer);
   }
 
   private KafkaDestination createKafkaDestination(

--- a/cli/src/test/java/com/datagenerator/cli/ExecuteCommandTest.java
+++ b/cli/src/test/java/com/datagenerator/cli/ExecuteCommandTest.java
@@ -592,7 +592,7 @@ class ExecuteCommandTest {
           case "none" -> "  compress: false";
           case "stream" -> "  compress: true";
           case "per_chunk" -> "  compress: true\n  compress_mode: per_chunk";
-          default -> throw new IllegalArgumentException("unknown mode: " + mode);
+          case null, default -> throw new IllegalArgumentException("unknown mode: " + mode);
         };
     return writeJobFile("file", extraConf);
   }

--- a/cli/src/test/java/com/datagenerator/cli/ExecuteCommandTest.java
+++ b/cli/src/test/java/com/datagenerator/cli/ExecuteCommandTest.java
@@ -25,18 +25,23 @@ import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.GZIPInputStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
@@ -53,6 +58,7 @@ class ExecuteCommandTest {
 
   private Path structDir;
   private Path outDir;
+  private final AtomicInteger jobFileCounter = new AtomicInteger();
 
   @BeforeEach
   void setUp() throws IOException {
@@ -110,6 +116,31 @@ class ExecuteCommandTest {
 
   private int execute(String... args) {
     return new CommandLine(new ExecuteCommand()).execute(args);
+  }
+
+  /**
+   * Writes a standalone job YAML with arbitrary extra top-level YAML lines (e.g. {@code type:},
+   * {@code seed:} block, {@code conf:} block). {@code structurePath} is the structure file's
+   * location relative to {@code tempDir} (e.g. {@code "structures/simple.yaml"}); {@code
+   * structures_path} is derived from its parent directory and {@code source} from its file name, so
+   * both the initial parse and the registry's by-name lookup (basePath + "{name}.yaml") resolve to
+   * the same file.
+   */
+  private Path writeJobYaml(String structurePath, String... lines) throws IOException {
+    Path jobFile = tempDir.resolve("job_" + jobFileCounter.incrementAndGet() + ".yaml");
+    Path resolvedStructurePath = tempDir.resolve(structurePath);
+    Path parent = resolvedStructurePath.getParent();
+    if (parent == null) {
+      throw new IllegalArgumentException("structurePath must include a parent directory");
+    }
+    StringBuilder yaml = new StringBuilder();
+    yaml.append("source: ").append(resolvedStructurePath.getFileName()).append('\n');
+    yaml.append("structures_path: ").append(parent.toAbsolutePath()).append('\n');
+    for (String line : lines) {
+      yaml.append(line).append('\n');
+    }
+    Files.writeString(jobFile, yaml.toString());
+    return jobFile;
   }
 
   // ── Happy path — JSON ────────────────────────────────────────────────────────
@@ -306,6 +337,315 @@ class ExecuteCommandTest {
             .isEqualTo(reference);
       }
     }
+  }
+
+  // ── Per-chunk gzip mode (issue #210): deterministic multi-member .gz ──────────────────
+
+  @Test
+  void shouldProduceIdenticalGzipAcrossThreadCounts() throws Exception {
+    // With compress_mode: per_chunk, the .gz should be byte-identical across threads
+    // because member boundaries = f(chunkSize, count), never thread count.
+    Path jobFile =
+        writeJobYaml(
+            "structures/simple.yaml",
+            "type: file",
+            "seed:",
+            "  type: embedded",
+            "  value: 999",
+            "conf:",
+            "  path: " + outDir.resolve("per_chunk").toAbsolutePath(),
+            "  compress: true",
+            "  compress_mode: per_chunk");
+
+    int count = 256 * 2 + 50; // 562 — 2 full chunks + 1 partial
+
+    byte[] reference = null;
+    for (int threads : new int[] {1, 2, 4}) {
+      Path output = outDir.resolve("per_chunk.json.gz");
+      if (Files.exists(output)) {
+        Files.delete(output);
+      }
+
+      int code =
+          execute(
+              OPT_JOB,
+              jobFile.toString(),
+              OPT_COUNT,
+              String.valueOf(count),
+              OPT_SEED,
+              "777",
+              "--threads",
+              String.valueOf(threads));
+      assertThat(code).isZero();
+
+      byte[] bytes = Files.readAllBytes(output);
+      if (reference == null) {
+        reference = bytes;
+      } else {
+        assertThat(bytes)
+            .as(
+                ".gz bytes with %d threads must be byte-identical to the 1-thread reference (issue #210)",
+                threads)
+            .isEqualTo(reference);
+      }
+    }
+  }
+
+  @Test
+  void shouldDecompressToSameBytesAsUncompressedRun() throws Exception {
+    // Verify that gunzip(per_chunk output) == plain uncompressed run's file bytes.
+    int count = 2500;
+
+    // Uncompressed run
+    Path jobFileUncompressed =
+        writeJobYaml(
+            "structures/simple.yaml",
+            "type: file",
+            "seed:",
+            "  type: embedded",
+            "  value: 888",
+            "conf:",
+            "  path: " + outDir.resolve("plain").toAbsolutePath(),
+            "  compress: false");
+
+    int codeUncompressed =
+        execute(
+            OPT_JOB,
+            jobFileUncompressed.toString(),
+            OPT_COUNT,
+            String.valueOf(count),
+            OPT_SEED,
+            "888");
+
+    assertThat(codeUncompressed).isZero();
+    byte[] uncompressedBytes = Files.readAllBytes(outDir.resolve("plain.json"));
+
+    // Per-chunk gzipped run
+    Path jobFileCompressed =
+        writeJobYaml(
+            "structures/simple.yaml",
+            "type: file",
+            "seed:",
+            "  type: embedded",
+            "  value: 888",
+            "conf:",
+            "  path: " + outDir.resolve("per_chunk").toAbsolutePath(),
+            "  compress: true",
+            "  compress_mode: per_chunk");
+
+    int codeCompressed =
+        execute(
+            OPT_JOB,
+            jobFileCompressed.toString(),
+            OPT_COUNT,
+            String.valueOf(count),
+            OPT_SEED,
+            "888");
+
+    assertThat(codeCompressed).isZero();
+
+    // Decompress and compare
+    java.io.ByteArrayOutputStream decompressed = new java.io.ByteArrayOutputStream();
+    try (java.util.zip.GZIPInputStream gz =
+        new java.util.zip.GZIPInputStream(
+            Files.newInputStream(outDir.resolve("per_chunk.json.gz")))) {
+      byte[] buffer = new byte[4096];
+      int len;
+      while ((len = gz.read(buffer)) != -1) {
+        decompressed.write(buffer, 0, len);
+      }
+    }
+
+    assertThat(decompressed.toByteArray()).isEqualTo(uncompressedBytes);
+  }
+
+  @Test
+  void shouldDecompressToSameBytesOnSingleThreadPath() throws Exception {
+    // Single-threaded path (count < threshold): verify gunzip(per_chunk) == plain output.
+    int count = 300;
+
+    // Uncompressed run
+    Path jobFileUncompressed =
+        writeJobYaml(
+            "structures/simple.yaml",
+            "type: file",
+            "seed:",
+            "  type: embedded",
+            "  value: 777",
+            "conf:",
+            "  path: " + outDir.resolve("plain_single").toAbsolutePath(),
+            "  compress: false");
+
+    int codeUncompressed =
+        execute(
+            OPT_JOB,
+            jobFileUncompressed.toString(),
+            OPT_COUNT,
+            String.valueOf(count),
+            OPT_SEED,
+            "777");
+
+    assertThat(codeUncompressed).isZero();
+    byte[] uncompressedBytes = Files.readAllBytes(outDir.resolve("plain_single.json"));
+
+    // Per-chunk gzipped run
+    Path jobFileCompressed =
+        writeJobYaml(
+            "structures/simple.yaml",
+            "type: file",
+            "seed:",
+            "  type: embedded",
+            "  value: 777",
+            "conf:",
+            "  path: " + outDir.resolve("per_chunk_single").toAbsolutePath(),
+            "  compress: true",
+            "  compress_mode: per_chunk");
+
+    int codeCompressed =
+        execute(
+            OPT_JOB,
+            jobFileCompressed.toString(),
+            OPT_COUNT,
+            String.valueOf(count),
+            OPT_SEED,
+            "777");
+
+    assertThat(codeCompressed).isZero();
+
+    // Decompress and compare
+    java.io.ByteArrayOutputStream decompressed = new java.io.ByteArrayOutputStream();
+    try (java.util.zip.GZIPInputStream gz =
+        new java.util.zip.GZIPInputStream(
+            Files.newInputStream(outDir.resolve("per_chunk_single.json.gz")))) {
+      byte[] buffer = new byte[4096];
+      int len;
+      while ((len = gz.read(buffer)) != -1) {
+        decompressed.write(buffer, 0, len);
+      }
+    }
+
+    assertThat(decompressed.toByteArray()).isEqualTo(uncompressedBytes);
+  }
+
+  // ── Compression determinism regression (issues #193 + #210): every write path is
+  //    thread-count-invariant on disk AND decompresses to the exact plain output ───────────
+
+  @ParameterizedTest(name = "compress mode: {0}")
+  @ValueSource(strings = {"none", "stream", "per_chunk"})
+  void compressedOutputIsDeterministicAndDecompressesToPlainAcrossThreadCounts(String mode)
+      throws Exception {
+    // Count deliberately not a multiple of chunkSize (256) so a partial final chunk is exercised.
+    int count = 256 * 3 + 7; // 775
+    long seed = 20210L;
+
+    // Plain reference content (also the decompressed target for the compressed modes).
+    byte[] plainReference =
+        Files.readAllBytes(
+            runAcrossThreadCounts(writeCompressJob("none"), "output.json", count, seed));
+
+    if ("none".equals(mode)) {
+      // The "none" case is fully asserted inside runAcrossThreadCounts (byte-identical raw output).
+      assertThat(plainReference).isNotEmpty();
+      return;
+    }
+
+    // Compressed modes: on-disk .gz must be byte-identical across thread counts, and must
+    // decompress back to the exact plain bytes.
+    Path gz = runAcrossThreadCounts(writeCompressJob(mode), "output.json.gz", count, seed);
+    assertThat(gunzip(gz))
+        .as("gunzip(%s output) must equal the plain uncompressed output", mode)
+        .isEqualTo(plainReference);
+  }
+
+  @Test
+  void perChunkGzipDiffersFromStreamOnDiskButDecompressesIdentically() throws Exception {
+    // Guards against a silent fallback to stream mode (e.g. compress_mode not wired through the
+    // CLI): the two modes MUST produce different .gz bytes (multi-member vs single-member) while
+    // decompressing to the same content.
+    int count = 256 * 3 + 7; // 775 — spans several chunks so per_chunk emits multiple members
+    long seed = 4242L;
+
+    Path streamGz =
+        runAcrossThreadCounts(writeCompressJob("stream"), "output.json.gz", count, seed);
+    byte[] streamBytes = Files.readAllBytes(streamGz);
+    byte[] streamContent = gunzip(streamGz);
+
+    Path perChunkGz =
+        runAcrossThreadCounts(writeCompressJob("per_chunk"), "output.json.gz", count, seed);
+    byte[] perChunkBytes = Files.readAllBytes(perChunkGz);
+
+    assertThat(perChunkBytes)
+        .as("per_chunk .gz must differ from stream .gz (proves compress_mode took effect)")
+        .isNotEqualTo(streamBytes);
+    assertThat(gunzip(perChunkGz))
+        .as("per_chunk and stream must decompress to identical content")
+        .isEqualTo(streamContent);
+  }
+
+  /**
+   * Build a file job at {@code outDir/output} with the given compression mode
+   * (none|stream|per_chunk).
+   */
+  private Path writeCompressJob(String mode) throws IOException {
+    String extraConf =
+        switch (mode) {
+          case "none" -> "  compress: false";
+          case "stream" -> "  compress: true";
+          case "per_chunk" -> "  compress: true\n  compress_mode: per_chunk";
+          default -> throw new IllegalArgumentException("unknown mode: " + mode);
+        };
+    return writeJobFile("file", extraConf);
+  }
+
+  /**
+   * Run the same job at {@code --threads 1/4/8} and assert the produced file is byte-identical
+   * across all three (the determinism guarantee). Returns the path of the produced file.
+   */
+  private Path runAcrossThreadCounts(Path jobFile, String outputName, int count, long seed)
+      throws Exception {
+    Path output = outDir.resolve(outputName);
+    byte[] reference = null;
+    for (int threads : new int[] {1, 4, 8}) {
+      if (Files.exists(output)) {
+        Files.delete(output);
+      }
+      int code =
+          execute(
+              OPT_JOB,
+              jobFile.toString(),
+              OPT_COUNT,
+              String.valueOf(count),
+              OPT_SEED,
+              String.valueOf(seed),
+              "--threads",
+              String.valueOf(threads));
+      assertThat(code).isZero();
+
+      byte[] bytes = Files.readAllBytes(output);
+      if (reference == null) {
+        reference = bytes;
+      } else {
+        assertThat(bytes)
+            .as(
+                "%s with %d threads must be byte-identical to the 1-thread reference",
+                outputName, threads)
+            .isEqualTo(reference);
+      }
+    }
+    return output;
+  }
+
+  /** Fully decompress a gzip file (transparently reads consecutive members). */
+  private byte[] gunzip(Path gzFile) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (GZIPInputStream gz = new GZIPInputStream(Files.newInputStream(gzFile))) {
+      byte[] buffer = new byte[8192];
+      int len;
+      while ((len = gz.read(buffer)) != -1) {
+        out.write(buffer, 0, len);
+      }
+    }
+    return out.toByteArray();
   }
 
   // ── Error cases ──────────────────────────────────────────────────────────────

--- a/config/README.md
+++ b/config/README.md
@@ -174,16 +174,24 @@ seed:
   value: 98765
 conf:
   path: build/run-output/customers
-  compress: true    # Enable gzip compression (.gz added automatically)
+  compress: true              # Enable gzip compression (.gz added automatically)
+  compress_mode: stream       # Optional: stream (default) or per_chunk
   append: false
 ```
 
+**`compress_mode` (optional, default `stream`):**
+- `stream` — single gzip stream on the writer thread; default behavior, unchanged from earlier versions.
+- `per_chunk` — each chunk gzipped independently on workers, then concatenated as multi-member gzip; requires `compress: true` and an NDJSON-style format (JSON/NDJSON only — CSV/Avro not supported). Decompressed output is identical to `stream` mode; compressed `.gz` bytes differ. Parallel workers remove compression from the writer-thread bottleneck, at a cost of slightly lower compression ratio due to smaller per-member dictionaries.
+
 **Usage**:
 ```bash
+# stream mode (default)
 ./gradlew :cli:run --args="execute --job config/jobs/file_customer_gzip.yaml --format json --count 1000"
+# per_chunk mode (parallel gzip)
+./gradlew :cli:run --args="execute --job config/jobs/file_customer_gzip_parallel.yaml --format json --count 1000"
 ```
 
-**Output**: `build/run-output/customers.json.gz` (valid gzip, decompresses to newline-delimited JSON)
+**Output**: `build/run-output/customers.json.gz` (valid gzip, decompresses to newline-delimited JSON — identical content in either mode)
 
 See `config/jobs/file_order.yaml` for a gzip example with nested structures.
 

--- a/config/jobs/file_customer_gzip_parallel.yaml
+++ b/config/jobs/file_customer_gzip_parallel.yaml
@@ -1,0 +1,15 @@
+# Parallel gzip (issue #210): each generation chunk is gzipped independently on a
+# worker thread and the writer concatenates them as a multi-member RFC 1952 gzip.
+# Moves deflate off the single writer thread; gunzip/GZIPInputStream read it transparently.
+# Same seed => byte-identical .gz across thread counts; decompressed bytes identical to
+# the default `stream` mode. JSON/NDJSON only (not CSV/Avro).
+source: customer.yaml
+type: file
+seed:
+  type: embedded
+  value: 98765
+conf:
+  path: build/run-output/customers
+  compress: true
+  compress_mode: per_chunk   # default is `stream` (single-stream gzip on the writer thread)
+  append: false

--- a/core/src/main/java/com/datagenerator/core/engine/GenerationEngine.java
+++ b/core/src/main/java/com/datagenerator/core/engine/GenerationEngine.java
@@ -107,15 +107,21 @@ public class GenerationEngine {
   private final SerializedWriter serializedWriter;
 
   /**
-   * Optional: folds a full chunk of serialized payloads (or, on the single-threaded path, a
-   * singleton one-payload "chunk") into a single combined payload before it reaches {@link
-   * #serializedWriter}. Typically {@code destination::coalesce}.
+   * Optional: folds a full chunk of serialized payloads into a single combined payload before it
+   * reaches {@link #serializedWriter}. Typically {@code destination::coalesce}.
    *
-   * <p>Applying this on the producer side (the worker thread in the multi-threaded path) moves the
-   * per-record concatenation work — e.g. appending newline delimiters — off the single writer
-   * thread: the writer then performs one {@code write()} call per chunk instead of one per record.
-   * Only meaningful together with {@link #recordSerializer} and {@link #serializedWriter}; ignored
-   * otherwise (the raw-{@code Map} pipeline never folds).
+   * <p>Applying this on the producer side (the worker thread in the multi-threaded path, or the
+   * main thread in the single-threaded path) moves the per-record concatenation work — e.g.
+   * appending newline delimiters — off the single writer thread: the writer then performs one
+   * {@code write()} call per chunk instead of one per record. Only meaningful together with {@link
+   * #recordSerializer} and {@link #serializedWriter}; ignored otherwise (the raw-{@code Map}
+   * pipeline never folds).
+   *
+   * <p>Both paths batch records into fixed-size chunks of {@link #chunkSize} (default 256) and
+   * apply the fold to each chunk: the single-threaded path accumulates payloads into a buffer and
+   * folds when reaching chunkSize or end-of-job, producing the same chunk layout (sizes) as the
+   * multi-threaded path for a given count/chunkSize combination. This ensures output is
+   * deterministic and uncompressed folded bytes are unchanged (concatenation is associative).
    *
    * <p>Leave unset for destinations where each payload must remain an independent write unit — e.g.
    * one Kafka message per record. Folding would merge multiple records into a single destination
@@ -209,9 +215,9 @@ public class GenerationEngine {
    * @param count number of records to generate
    * @param produce builds one payload from a thread-local {@link Random} (runs on workers)
    * @param consume writes one payload (runs on the single writer thread)
-   * @param chunkTransform optional fold applied to each chunk (or single-record "chunk" on the
-   *     single-threaded path) before its payloads reach {@code consume}; {@code null} to pass
-   *     payloads through unchanged
+   * @param chunkTransform optional fold applied to each full chunk (fixed-size batches of {@link
+   *     #chunkSize} records in both single- and multi-threaded paths) before its payloads reach
+   *     {@code consume}; {@code null} to pass payloads through unchanged (one per record)
    */
   private <P> void runPipeline(
       long count,
@@ -236,32 +242,67 @@ public class GenerationEngine {
       UnaryOperator<List<P>> chunkTransform) {
     RandomProvider randomProvider = new RandomProvider(masterSeed);
     Random random = randomProvider.getRandom();
-
     long startTime = System.currentTimeMillis();
 
-    for (long i = 0; i < count; i++) {
-      // Seed by global record index so output matches the multi-threaded path byte-for-byte.
-      random.setSeed(randomProvider.deriveRecordSeed(i));
-      P payload = produce.apply(random);
-      if (chunkTransform == null) {
-        consume.accept(payload);
-      } else {
-        // Fold this single record as a one-element "chunk" so a coalescing destination sees the
-        // same framing it would from the multi-threaded path, regardless of job size.
-        for (P item : chunkTransform.apply(List.of(payload))) {
-          consume.accept(item);
-        }
-      }
-
-      // Progress logging
-      if ((i + 1) % logBatchSize == 0) {
-        logProgress(i + 1, count, startTime);
-      }
+    if (chunkTransform == null) {
+      runSingleThreadedUnfolded(count, produce, consume, randomProvider, random, startTime);
+    } else {
+      runSingleThreadedFolded(
+          count, produce, consume, chunkTransform, randomProvider, random, startTime);
     }
 
     logProgress(count, count, startTime); // Final progress
     workerCleanup.run();
     log.info("Single-threaded generation complete");
+  }
+
+  /** No folding: consume each record as it is produced (raw {@code Map} / non-coalescing path). */
+  @SuppressWarnings("java:S107")
+  private <P> void runSingleThreadedUnfolded(
+      long count,
+      Function<Random, P> produce,
+      Consumer<P> consume,
+      RandomProvider randomProvider,
+      Random random,
+      long startTime) {
+    for (long i = 0; i < count; i++) {
+      random.setSeed(randomProvider.deriveRecordSeed(i));
+      consume.accept(produce.apply(random));
+      if ((i + 1) % logBatchSize == 0) {
+        logProgress(i + 1, count, startTime);
+      }
+    }
+  }
+
+  /**
+   * Batch payloads into {@code chunkSize} and fold each full batch (mirrors multi-threaded path).
+   */
+  @SuppressWarnings("java:S107")
+  private <P> void runSingleThreadedFolded(
+      long count,
+      Function<Random, P> produce,
+      Consumer<P> consume,
+      UnaryOperator<List<P>> chunkTransform,
+      RandomProvider randomProvider,
+      Random random,
+      long startTime) {
+    List<P> buffer = new ArrayList<>(chunkSize);
+    for (long i = 0; i < count; i++) {
+      random.setSeed(randomProvider.deriveRecordSeed(i));
+      buffer.add(produce.apply(random));
+
+      // When the buffer reaches chunkSize or this is the last record, fold and consume.
+      if (buffer.size() == chunkSize || i == count - 1) {
+        for (P item : chunkTransform.apply(buffer)) {
+          consume.accept(item);
+        }
+        buffer.clear();
+      }
+
+      if ((i + 1) % logBatchSize == 0) {
+        logProgress(i + 1, count, startTime);
+      }
+    }
   }
 
   /**

--- a/core/src/test/java/com/datagenerator/core/engine/GenerationEngineTest.java
+++ b/core/src/test/java/com/datagenerator/core/engine/GenerationEngineTest.java
@@ -433,10 +433,11 @@ class GenerationEngineTest {
   }
 
   @Test
-  void shouldFoldSingleThreadedRecordsIndividuallyWhenBelowThreshold() throws InterruptedException {
-    // Below singleThreadedThreshold: no chunk batching happens, but the fold must still apply to
-    // each record individually (as a singleton "chunk") so a coalescing destination sees the same
-    // per-record framing it would on the multi-threaded path.
+  void shouldFoldSingleThreadedRecordsAsOneChunkWhenBelowChunkSize() throws InterruptedException {
+    // Below singleThreadedThreshold: the single-threaded path batches records to chunkSize before
+    // folding (mirroring the multi-threaded chunk layout). 50 records < chunkSize 256 -> exactly
+    // one fold over all 50, so a coalescing destination sees the same chunk framing it would on
+    // the multi-threaded path.
     AtomicInteger idCounter = new AtomicInteger(0);
     GenerationEngine.RecordGenerator recordGenerator =
         random -> Map.of("id", idCounter.incrementAndGet());
@@ -456,10 +457,11 @@ class GenerationEngineTest {
 
     engine.generate(50);
 
-    // Each record folded (as a singleton) and written individually — one writer call per record.
-    assertThat(writtenItems).hasSize(50);
-    assertThat(new String(writtenItems.get(0), java.nio.charset.StandardCharsets.UTF_8))
-        .isEqualTo("id=1\n");
+    // All 50 records folded as one chunk — a single writer call carrying every record in order.
+    assertThat(writtenItems).hasSize(1);
+    String folded = new String(writtenItems.get(0), java.nio.charset.StandardCharsets.UTF_8);
+    assertThat(folded).startsWith("id=1\nid=2\n").endsWith("id=50\n");
+    assertThat(folded.split("\n")).hasSize(50);
   }
 
   @Test
@@ -584,5 +586,54 @@ class GenerationEngineTest {
     assertThat(writtenChunks).hasSize(3); // 2 full + 1 partial, none empty/skipped
     // Last chunk folded from exactly 5 records ("x\n" each) = 10 bytes.
     assertThat(writtenChunks.get(2)).hasSize(5 * 2);
+  }
+
+  // ── Single-threaded path chunk batching (issue #210) ──────────────────────────────────
+
+  @Test
+  void shouldFoldFullChunksOnSingleThreadedPath() throws InterruptedException {
+    // Single-threaded path (count < threshold): chunkTransform should batch records into
+    // chunkSize-bounded chunks (256 by default), not apply per-record. Verify fold input sizes
+    // match the multi-threaded expectation: [256, 256, 88] for 600 records.
+    GenerationEngine.RecordGenerator recordGenerator = random -> Map.of("id", 1);
+    GenerationEngine.RecordSerializer serializer =
+        data -> "r".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+    List<List<byte[]>> foldInputs = new ArrayList<>();
+    GenerationEngine.ChunkFolder folder =
+        payloads -> {
+          synchronized (foldInputs) {
+            foldInputs.add(new ArrayList<>(payloads));
+          }
+          return newlineJoin(payloads);
+        };
+
+    List<byte[]> writtenChunks = new ArrayList<>();
+    GenerationEngine.SerializedWriter writer =
+        bytes -> {
+          synchronized (writtenChunks) {
+            writtenChunks.add(bytes);
+          }
+        };
+
+    int recordCount = 600; // 2 full chunks (256 each) + 1 partial (88)
+    GenerationEngine.builder()
+        .recordGenerator(recordGenerator)
+        .recordSerializer(serializer)
+        .serializedWriter(writer)
+        .chunkFolder(folder)
+        .masterSeed(1L)
+        .singleThreadedThreshold(Integer.MAX_VALUE) // Force single-threaded path
+        .build()
+        .generate(recordCount);
+
+    // Verify fold was called 3 times with chunk sizes matching multi-threaded layout
+    assertThat(foldInputs).hasSize(3);
+    assertThat(foldInputs.get(0)).hasSize(256);
+    assertThat(foldInputs.get(1)).hasSize(256);
+    assertThat(foldInputs.get(2)).hasSize(88);
+
+    // Written chunks should match
+    assertThat(writtenChunks).hasSize(3);
   }
 }

--- a/destinations/src/main/java/com/datagenerator/destinations/file/FileDestination.java
+++ b/destinations/src/main/java/com/datagenerator/destinations/file/FileDestination.java
@@ -22,6 +22,7 @@ import com.datagenerator.formats.FormatSerializer;
 import com.datagenerator.formats.FormatSerializer.StreamWriter;
 import com.datagenerator.formats.avro.AvroSerializer;
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -46,7 +47,7 @@ import org.apache.avro.generic.GenericRecord;
  *   <li>Java NIO for fast I/O
  *   <li>Buffered writes (configurable buffer size via {@link
  *       FileDestinationConfig#getBufferSize()})
- *   <li>Optional gzip compression
+ *   <li>Optional gzip compression (serial "stream" mode or parallel "per_chunk" mode)
  *   <li>Append mode support
  *   <li>CSV header row (for CSV format)
  *   <li>Automatic parent directory creation
@@ -77,10 +78,15 @@ import org.apache.avro.generic.GenericRecord;
  */
 @Slf4j
 public class FileDestination extends AbstractDestination {
+  private static final String MODE_STREAM = "stream";
+  private static final String MODE_PER_CHUNK = "per_chunk";
+
   private final FileDestinationConfig config;
   private final FormatSerializer serializer;
 
   private boolean headerWritten = false;
+  private boolean perChunkGzip = false;
+  private boolean anyChunkWritten = false;
 
   // Text-format state
   private OutputStream outputStream;
@@ -109,6 +115,8 @@ public class FileDestination extends AbstractDestination {
       log.warn("File destination already open: {}", config.getFilePath());
       return;
     }
+
+    validateCompressMode();
 
     try {
       Path filePath = config.getFilePath();
@@ -140,7 +148,9 @@ public class FileDestination extends AbstractDestination {
           filePath = Path.of(filePath.toString() + ".gz");
         }
         OutputStream base = Files.newOutputStream(filePath, openOptions);
-        if (config.isCompress()) {
+        // When perChunkGzip is true, do NOT wrap GZIPOutputStream here; each chunk is gzipped
+        // on the worker thread and the writer concatenates the members.
+        if (config.isCompress() && !perChunkGzip) {
           base = new GZIPOutputStream(base);
         }
         outputStream = new BufferedOutputStream(base, config.getBufferSize());
@@ -160,9 +170,31 @@ public class FileDestination extends AbstractDestination {
     }
   }
 
+  /** Validate {@code compress_mode} and resolve the {@link #perChunkGzip} flag (fail fast). */
+  private void validateCompressMode() {
+    String compressMode = config.getCompressMode();
+    if (!MODE_STREAM.equals(compressMode) && !MODE_PER_CHUNK.equals(compressMode)) {
+      throw new DestinationException(
+          "Unknown compress_mode '" + compressMode + "'. Valid values: stream, per_chunk");
+    }
+    boolean perChunk = MODE_PER_CHUNK.equals(compressMode);
+    if (perChunk && !config.isCompress()) {
+      throw new DestinationException("compress_mode: per_chunk requires compress: true");
+    }
+    if (perChunk && !supportsWriteCoalescing()) {
+      throw new DestinationException(
+          "compress_mode: per_chunk requires an NDJSON-style format; csv/avro serialize on the writer thread");
+    }
+    perChunkGzip = config.isCompress() && perChunk;
+  }
+
   @Override
   public void write(Map<String, Object> data) {
     requireOpen("File");
+
+    if (perChunkGzip) {
+      throw new DestinationException("per_chunk compression requires the serialized write path");
+    }
 
     if (isAvro) {
       writeAvro(data);
@@ -199,8 +231,17 @@ public class FileDestination extends AbstractDestination {
   public void writeSerialized(byte[] payload) {
     requireOpen("File");
     try {
-      outputStream.write(payload);
-      outputStream.write('\n');
+      if (perChunkGzip) {
+        // Defensive: engine never calls this when coalescing is wired, but keep the contract valid.
+        byte[] framed = new byte[payload.length + 1];
+        System.arraycopy(payload, 0, framed, 0, payload.length);
+        framed[payload.length] = '\n';
+        outputStream.write(gzipMember(framed));
+      } else {
+        outputStream.write(payload);
+        outputStream.write('\n');
+      }
+      anyChunkWritten = true;
     } catch (IOException e) {
       throw new DestinationException("Failed to write serialized record to file", e);
     }
@@ -226,6 +267,10 @@ public class FileDestination extends AbstractDestination {
       pos += payload.length;
       combined[pos++] = '\n';
     }
+    // If per_chunk gzip mode, wrap the combined payload as an independent gzip member.
+    if (perChunkGzip) {
+      return gzipMember(combined);
+    }
     return combined;
   }
 
@@ -233,11 +278,34 @@ public class FileDestination extends AbstractDestination {
   public void writeSerializedChunk(byte[] coalescedPayload) {
     requireOpen("File");
     try {
-      // coalesce() already interleaved each record with its trailing newline; write as-is.
+      // When perChunkGzip is true, coalesce() has already gzipped the payload as an independent
+      // member; write as-is. Otherwise, coalesce() returns plain concatenated bytes.
       outputStream.write(coalescedPayload);
+      anyChunkWritten = true;
     } catch (IOException e) {
       throw new DestinationException("Failed to write coalesced records to file", e);
     }
+  }
+
+  /**
+   * Gzip-compress a raw byte array as an independent gzip member.
+   *
+   * <p>Runs on worker threads during parallel generation. Thread-safe and stateless. Returns a
+   * complete gzip member that can be written to the output stream; multiple members are
+   * concatenated to form a valid multi-member .gz file (RFC 1952).
+   *
+   * @param raw raw bytes to compress
+   * @return gzipped bytes (complete gzip member)
+   * @throws DestinationException if compression fails
+   */
+  private byte[] gzipMember(byte[] raw) {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(Math.max(64, raw.length / 3));
+    try (GZIPOutputStream gz = new GZIPOutputStream(baos)) {
+      gz.write(raw);
+    } catch (IOException e) {
+      throw new DestinationException("Failed to gzip chunk", e);
+    }
+    return baos.toByteArray();
   }
 
   private void writeAvro(Map<String, Object> data) {
@@ -294,6 +362,10 @@ public class FileDestination extends AbstractDestination {
           avroRawOut.close();
         }
       } else {
+        // If per_chunk gzip and no chunks were written, emit an empty member so the .gz is valid.
+        if (perChunkGzip && !anyChunkWritten) {
+          outputStream.write(gzipMember(new byte[0]));
+        }
         flush();
         streamWriter.close();
         outputStream.close();

--- a/destinations/src/main/java/com/datagenerator/destinations/file/FileDestinationConfig.java
+++ b/destinations/src/main/java/com/datagenerator/destinations/file/FileDestinationConfig.java
@@ -56,4 +56,19 @@ public class FileDestinationConfig {
    * per-record writes). Set to 1 to disable batching.
    */
   @Builder.Default int batchSize = 1000;
+
+  /**
+   * Compression mode for gzip output. Controls how gzip compression is applied when compress=true.
+   *
+   * <ul>
+   *   <li>"stream" (default): Single GZIPOutputStream wrapping the writer thread output stream.
+   *       Deflate runs serially on the writer thread, sequential/deterministic member layout.
+   *       Maintains existing behavior.
+   *   <li>"per_chunk": Each engine chunk is independently gzipped on a worker thread as an
+   *       independent gzip member. The writer concatenates complete members in chunk order.
+   *       Multi-member RFC 1952 .gz file; parallel deflate (scales with worker threads). Requires
+   *       compress=true and an NDJSON-style format (JSON, not CSV/Avro).
+   * </ul>
+   */
+  @Builder.Default String compressMode = "stream";
 }

--- a/destinations/src/test/java/com/datagenerator/destinations/file/FileDestinationTest.java
+++ b/destinations/src/test/java/com/datagenerator/destinations/file/FileDestinationTest.java
@@ -445,4 +445,157 @@ class FileDestinationTest {
     long lineCount = Files.lines(outputFile).count();
     assertThat(lineCount).isEqualTo(10000);
   }
+
+  // ── Per-chunk gzip mode (issue #210) ──────────────────────────────────────
+
+  @Test
+  void shouldGzipCoalescedChunkPerMember() throws Exception {
+    // With compress_mode: per_chunk, coalesce should return a gzipped byte[] of the combined
+    // payloads (each joined with a trailing '\n'), forming one complete gzip member.
+    Path outputFile = tempDir.resolve("per_chunk.json");
+    FileDestinationConfig config =
+        configBuilder.filePath(outputFile).compress(true).compressMode("per_chunk").build();
+
+    FileDestination destination = new FileDestination(config, new JsonSerializer());
+    destination.open();
+
+    byte[] p1 = "{\"a\":1}".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    byte[] p2 = "{\"b\":2}".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+    byte[] member = destination.coalesce(List.of(p1, p2));
+
+    // Decompress with GZIPInputStream — should equal "{\"a\":1}\n{\"b\":2}\n"
+    java.io.ByteArrayInputStream bais = new java.io.ByteArrayInputStream(member);
+    java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+    try (GZIPInputStream gz = new GZIPInputStream(bais)) {
+      byte[] buffer = new byte[1024];
+      int len;
+      while ((len = gz.read(buffer)) != -1) {
+        baos.write(buffer, 0, len);
+      }
+    }
+
+    byte[] decompressed = baos.toByteArray();
+    String expected = "{\"a\":1}\n{\"b\":2}\n";
+    assertThat(decompressed).isEqualTo(expected.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+    destination.close();
+  }
+
+  @Test
+  void shouldWriteValidMultiMemberGzipFile() throws Exception {
+    // Full flow: open per_chunk dest, write two coalesced chunks, close; read the .gz file
+    // with a single GZIPInputStream (Java reads consecutive members transparently) and verify
+    // all content is present in order.
+    Path outputFile = tempDir.resolve("per_chunk_full.json");
+    FileDestinationConfig config =
+        configBuilder.filePath(outputFile).compress(true).compressMode("per_chunk").build();
+
+    byte[] p1 = "{\"id\":1}".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    byte[] p2 = "{\"id\":2}".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    byte[] p3 = "{\"id\":3}".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    byte[] p4 = "{\"id\":4}".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+    try (FileDestination destination = new FileDestination(config, new JsonSerializer())) {
+      destination.open();
+
+      byte[] chunk1 = destination.coalesce(List.of(p1, p2));
+      // Each coalesced chunk must be an independent gzip member (magic 0x1f 0x8b) — this is what
+      // distinguishes per_chunk from stream mode, where coalesce() returns raw concatenated bytes.
+      assertThat(chunk1[0] & 0xff).isEqualTo(0x1f);
+      assertThat(chunk1[1] & 0xff).isEqualTo(0x8b);
+      destination.writeSerializedChunk(chunk1);
+
+      byte[] chunk2 = destination.coalesce(List.of(p3, p4));
+      assertThat(chunk2[0] & 0xff).isEqualTo(0x1f);
+      assertThat(chunk2[1] & 0xff).isEqualTo(0x8b);
+      destination.writeSerializedChunk(chunk2);
+    }
+
+    // File should have .gz extension
+    Path gzFile = Path.of(outputFile.toString() + ".gz");
+    assertThat(gzFile).exists();
+
+    // Decompress and read all records
+    List<String> lines = new ArrayList<>();
+    try (BufferedReader reader =
+        new BufferedReader(
+            new InputStreamReader(new GZIPInputStream(Files.newInputStream(gzFile))))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        lines.add(line);
+      }
+    }
+
+    assertThat(lines).hasSize(4);
+    assertThat(lines.get(0)).isEqualTo("{\"id\":1}");
+    assertThat(lines.get(1)).isEqualTo("{\"id\":2}");
+    assertThat(lines.get(2)).isEqualTo("{\"id\":3}");
+    assertThat(lines.get(3)).isEqualTo("{\"id\":4}");
+  }
+
+  @Test
+  void shouldWriteValidEmptyGzipWhenNoRecords() throws Exception {
+    // open + close with zero writes should yield a valid empty .gz that GZIPInputStream
+    // can read without exception.
+    Path outputFile = tempDir.resolve("per_chunk_empty.json");
+    FileDestinationConfig config =
+        configBuilder.filePath(outputFile).compress(true).compressMode("per_chunk").build();
+
+    try (FileDestination destination = new FileDestination(config, new JsonSerializer())) {
+      destination.open();
+      // No writes
+    }
+
+    Path gzFile = Path.of(outputFile.toString() + ".gz");
+    assertThat(gzFile).exists();
+
+    // Should be readable and yield zero bytes without exception
+    int bytesRead = 0;
+    try (GZIPInputStream gz = new GZIPInputStream(Files.newInputStream(gzFile))) {
+      byte[] buffer = new byte[1024];
+      bytesRead = gz.read(buffer);
+    }
+
+    assertThat(bytesRead).isEqualTo(-1); // EOF immediately
+  }
+
+  @Test
+  void shouldFailFastWhenPerChunkWithoutCompress() {
+    Path outputFile = tempDir.resolve("per_chunk_no_compress.json");
+    FileDestinationConfig config =
+        configBuilder.filePath(outputFile).compress(false).compressMode("per_chunk").build();
+
+    FileDestination destination = new FileDestination(config, new JsonSerializer());
+
+    assertThatThrownBy(destination::open)
+        .isInstanceOf(DestinationException.class)
+        .hasMessageContaining("compress: true");
+  }
+
+  @Test
+  void shouldFailFastWhenPerChunkWithCsv() {
+    Path outputFile = tempDir.resolve("per_chunk_csv.csv");
+    FileDestinationConfig config =
+        configBuilder.filePath(outputFile).compress(true).compressMode("per_chunk").build();
+
+    FileDestination destination = new FileDestination(config, new CsvSerializer());
+
+    assertThatThrownBy(destination::open)
+        .isInstanceOf(DestinationException.class)
+        .hasMessageContaining("NDJSON");
+  }
+
+  @Test
+  void shouldFailFastOnUnknownCompressMode() {
+    Path outputFile = tempDir.resolve("per_chunk_unknown.json");
+    FileDestinationConfig config =
+        configBuilder.filePath(outputFile).compress(true).compressMode("zstd").build();
+
+    FileDestination destination = new FileDestination(config, new JsonSerializer());
+
+    assertThatThrownBy(destination::open)
+        .isInstanceOf(DestinationException.class)
+        .hasMessageContaining("compress_mode");
+  }
 }


### PR DESCRIPTION
## Summary
`compress: true` gzips on the single writer thread (`GZIPOutputStream`), making deflate the throughput ceiling on many-core machines (issue #210). Single-stream deflate can't be parallelised byte-identically — dictionary + block decisions chain across the whole stream — so this adds an **opt-in** alternative that gzips each generation chunk independently on the workers and concatenates them as a multi-member RFC 1952 gzip.

## What changed
- New file-destination key **`compress_mode: stream (default) | per_chunk`**.
  - `stream` — byte-for-byte unchanged from today.
  - `per_chunk` — each chunk gzipped on a worker as its own gzip member; writer concatenates members. Deflate moves off the writer thread.
- **Gated**: `per_chunk` requires `compress: true` and an NDJSON-style format (JSON only). CSV/Avro serialize on the writer thread and are rejected fast at `open()`.
- Engine single-threaded path now folds full `chunkSize` batches (was per-record singletons) so its chunk layout matches the multi-threaded path.

## Determinism (unchanged guarantees)
- Member boundaries = `f(chunkSize, count)`, **never** thread count → per_chunk `.gz` is byte-identical across thread counts and machines for a given seed.
- Decompressed output is identical to `stream` mode — the **hard** determinism guarantee. Compressed `.gz` bytes differ between modes (per-member dictionaries) and cost a few % ratio. Multi-member gzip is transparent to `gunzip`/`GZIPInputStream`.

## Testing
- Unit: multi-member round-trip + `coalesce()` returns a gzip **member** (magic `1f 8b`) — distinguishes per_chunk from stream.
- CLI regression (parametrized over `none`/`stream`/`per_chunk`): on-disk bytes thread-count-invariant **and** decompress to the exact plain output; plus a guard that per_chunk `.gz` **differs** from stream on disk (catches silent `compress_mode` fallback).
- Engine: single-threaded path folds `[256, 256, …]` batches.
- Verified end-to-end: 50001 records → 196 members, byte-identical across `--threads 1/8`, `gunzip -t` clean, decompresses identically to the uncompressed run. Local SonarQube gate green, 0 new issues.

## Docs
README determinism section, `config/README.md`, `CHANGELOG.md`, and a runnable example job `config/jobs/file_customer_gzip_parallel.yaml`.

Closes #210