### PR TITLE
feat(use-cases): developer environment bootstrapping (Closes #79)

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -4,3 +4,4 @@
 # SET QUOTED_IDENTIFIER), so exclude them from analysis.
 exclude_paths:
   - 'config/sql/**'
+  - '**/*.sql'

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,7 +1,7 @@
 ---
-# SQL files here are database DDL/fixtures, not application code. Codacy applies a
-# SQL Server (T-SQL) linter that misfires on PostgreSQL syntax (e.g. demanding
-# SET QUOTED_IDENTIFIER), so exclude them from analysis.
+# SQL files here are database DDL/fixtures, not application code. Codacy applies a fixed
+# SQL Server (T-SQL) linter that misfires on other SQL dialects (e.g. demanding
+# SET QUOTED_IDENTIFIER); SeedStream is engine-agnostic, so exclude .sql from analysis.
 exclude_paths:
   - 'config/sql/**'
   - '**/*.sql'

--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -85,6 +85,21 @@ Common exclusions:
 - Test utilities
 - Known false positives
 
+### Codacy
+
+Configuration: `.codacy.yml` (repo root). Runs as a required PR check (cloud).
+
+**Excluded from analysis:** `**/*.sql`
+
+Codacy lints SQL with a **SQL Server (T-SQL)** ruleset that misfires on PostgreSQL
+DDL — e.g. it demands `SET QUOTED_IDENTIFIER ON` at the top of every file. Every `.sql`
+in this repo is PostgreSQL DDL / seed fixtures (`config/sql/**`,
+`use-cases/**/schema.sql`) — **not application or test code** — so excluding it silences
+only false positives, not real findings. The exclusion is intentionally scoped to `.sql`;
+do not broaden it to source or test paths to quiet a warning. If real SQL *logic* ever
+ships (stored procedures, app queries), lint it with a PostgreSQL-aware tool instead of
+removing this guard.
+
 ### JaCoCo
 
 Configuration: `build.gradle.kts`

--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -91,14 +91,14 @@ Configuration: `.codacy.yml` (repo root). Runs as a required PR check (cloud).
 
 **Excluded from analysis:** `**/*.sql`
 
-Codacy lints SQL with a **SQL Server (T-SQL)** ruleset that misfires on PostgreSQL
-DDL — e.g. it demands `SET QUOTED_IDENTIFIER ON` at the top of every file. Every `.sql`
-in this repo is PostgreSQL DDL / seed fixtures (`config/sql/**`,
-`use-cases/**/schema.sql`) — **not application or test code** — so excluding it silences
-only false positives, not real findings. The exclusion is intentionally scoped to `.sql`;
-do not broaden it to source or test paths to quiet a warning. If real SQL *logic* ever
-ships (stored procedures, app queries), lint it with a PostgreSQL-aware tool instead of
-removing this guard.
+Codacy lints SQL with a fixed **SQL Server (T-SQL)** ruleset that misfires on other
+dialects — e.g. it demands `SET QUOTED_IDENTIFIER ON` at the top of every file. SeedStream
+is engine-agnostic (PostgreSQL, MySQL, Oracle, SQL Server), and every `.sql` in this repo
+is DDL / seed fixtures (`config/sql/**`, `use-cases/**/schema.sql`) — **not application or
+test code** — so excluding it silences only cross-dialect false positives, not real
+findings. The exclusion is intentionally scoped to `.sql`; do not broaden it to source or
+test paths to quiet a warning. If real SQL *logic* ever ships (stored procedures, app
+queries), lint it with a dialect-appropriate tool instead of removing this guard.
 
 ### JaCoCo
 

--- a/use-cases/README.md
+++ b/use-cases/README.md
@@ -10,7 +10,7 @@ sample structures, see [`config/`](../config/) and the [root README](../README.m
 | Use case | Persona | Outcome | Status | Link |
 |---|---|---|---|---|
 | DORA / GDPR resilience testing | Regulated finance (bank / insurer / fintech) | Reproducible ISO 20022 SEPA dataset for load/resilience tests — no production PII in non-prod | **Ready** | [`dora-gdpr-sepa-payments/`](dora-gdpr-sepa-payments/) |
-| Developer environment bootstrapping | Application developer | Realistic local dataset to run against | *Planned* ([#79](https://github.com/mferretti/SeedStream/issues/79)) | — |
+| Developer environment bootstrapping | Application developer | One command fills a local DB with a linked users/orders/line-items dataset — no prod dump | **Ready** | [`dev-env-bootstrapping/`](dev-env-bootstrapping/) |
 | CI pipeline database seeding | Platform / DevOps | Deterministic DB seed per CI run | *Planned* ([#80](https://github.com/mferretti/SeedStream/issues/80)) | — |
 | Performance and load testing | Performance engineer | High-volume synthetic data for benchmarks | *Planned* ([#81](https://github.com/mferretti/SeedStream/issues/81)) | — |
 | SaaS demo environments | Sales / solutions engineering | Convincing demo data for prospect environments | *Planned* ([#82](https://github.com/mferretti/SeedStream/issues/82)) | — |

--- a/use-cases/dev-env-bootstrapping/README.md
+++ b/use-cases/dev-env-bootstrapping/README.md
@@ -1,0 +1,92 @@
+# Developer environment bootstrapping
+
+**Persona:** an application developer joining a team, spinning up a feature branch, or standing up an
+ephemeral Kubernetes preview environment.
+**Outcome:** one script turns an empty Postgres into a realistic, fully linked task-tracker dataset
+(`users · projects · tasks · comments · labels · task_labels`) — **no production dump, no GDPR/PII
+risk, no hand-written fixtures.**
+
+## The scenario
+
+A new developer clones the repo and needs a populated database to run and debug against. The old
+answer — "copy production and sanitise" — drags real customer PII onto a laptop and is increasingly
+blocked by GDPR / DORA / EU AI Act obligations. Instead, SeedStream seeds from versioned YAML:
+
+```bash
+export DB_PASSWORD=devpass
+./bootstrap.sh          # creates the schema, then seeds every table in FK order
+```
+
+Fixed seeds make the dataset **byte-for-byte identical for every developer**, so a bug reported on
+one laptop reproduces on every other.
+
+## How referential integrity holds — no magic, no new engine features
+
+SeedStream's reference generator is **stateless and streaming**: `ref[t.id, min..max]` samples a
+uniform id from a declared range; it never stores generated ids. Integrity therefore comes from a
+convention, not enforcement:
+
+1. **The database owns the PKs.** Every `id` is `GENERATED ALWAYS AS IDENTITY`, so Postgres assigns a
+   **dense `1..N`** sequence. The structures **omit `id` entirely** — SeedStream generates no PK.
+2. **Children reference that dense pool with a static range.** `projects.owner_id =
+   ref[users.id, 1..200]` samples `1..200`; because users are exactly `1..200`, every FK resolves.
+3. **Parents are seeded before children** (`bootstrap.sh` order).
+
+That's the whole mechanism. Verified end-to-end against Postgres with all FK constraints enabled:
+**zero orphan rows** across the multi-parent (`tasks`, `comments`) and M:N (`task_labels`) edges.
+
+> **Keep counts and ranges in sync.** The static ranges in `structures/*.yaml` (`1..200`, `1..50`,
+> `1..500`) must match the `--count` values in `bootstrap.sh`. Change them together, or a child can
+> reference an id beyond the parent pool.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `schema.sql` | Postgres DDL — 6 tables, IDENTITY PKs, FK constraints, `CHECK` enums |
+| `structures/*.yaml` | One flat record per table, **no `id`**, FK columns as static-range `ref[]` |
+| `jobs/db_*.yaml` | One database job per table (fixed seed, Postgres) |
+| `bootstrap.sh` | Creates schema, seeds all tables parent-first with matching counts |
+
+`structures_path` is omitted from the jobs on purpose: living in a dir ending `jobs`, the CLI
+auto-resolves the sibling `../structures/`, so this folder is self-contained and relocatable.
+
+## Prerequisites
+
+- A reachable Postgres (jobs target `localhost:5432/devdb` — edit `jobs/*.yaml` for your own).
+- `DB_PASSWORD` exported.
+- SeedStream on `PATH` (or `export SEEDSTREAM=/path/to/bin/cli`).
+- **JDBC driver dropped into the distribution's `extras/` dir.** Drivers are not bundled — the dist is
+  vendor-neutral by design and `extras/*` is prepended to the classpath at startup (see
+  `docs/CONTAINER.md`, `docs/PERFORMANCE.md`).
+
+## Reseeding
+
+`bootstrap.sh` re-runs `schema.sql`, which `DROP … CASCADE`s and recreates the tables — so it resets
+to the known-good baseline every time. To reseed data without recreating the schema, add
+`truncate_before_insert: true` to the jobs (TRUNCATE … CASCADE; local/disposable DB only).
+
+## Limits (honest)
+
+- **Fields are independent.** No cross-field correlation — a `comment.body` is unrelated to its task,
+  a task's `status` unrelated to its `project`. SeedStream generates plausible shapes, not a coherent
+  narrative.
+- **`parent_task_id` is left NULL.** Self-referencing FKs need deferrable constraints or an ordered
+  pass SeedStream does not do today → no subtask hierarchy is generated. Tracked in
+  [#213](https://github.com/mferretti/SeedStream/issues/213).
+- **`task_labels` pairs can repeat.** With random refs a `(task_id, label_id)` pair may appear twice;
+  that's why the join table has a surrogate PK and no `UNIQUE(task_id,label_id)`. A `unique` generator
+  ([#212](https://github.com/mferretti/SeedStream/issues/212)) would let you add that constraint.
+- **Counts are uniform-ish / hand-tuned.** Ranges are static literals tied to the bootstrap counts,
+  not auto-derived from parent volumes.
+- **Postgres-shaped.** IDENTITY + `DROP … CASCADE`. Adapt DDL for other engines.
+
+## Where this comes from
+
+You don't have to hand-write the structures. `seedstream inspect schema.sql --output structures/`
+generates one flat structure per `CREATE TABLE` and emits each FK as `ref[table.column, 1..count]`
+already. After inspecting, you delete the emitted `id` lines (the DB assigns them) and switch the
+`1..count` ranges to static parent volumes — exactly what ships here. Two inspect enhancements would
+remove those manual steps: skip identity PKs on emit
+([#215](https://github.com/mferretti/SeedStream/issues/215)) and map `CHECK IN(...)` to `enum[...]`
+([#214](https://github.com/mferretti/SeedStream/issues/214)).

--- a/use-cases/dev-env-bootstrapping/bootstrap.sh
+++ b/use-cases/dev-env-bootstrapping/bootstrap.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Developer-environment bootstrap (issue #79): create the schema, then seed every table in FK order.
+# A new developer runs this once and gets a fully populated local task-tracker database — no prod
+# dump, no PII. The fixed seed in each job makes the dataset identical for everyone on the team.
+#
+# Prerequisites:
+#   * A reachable Postgres (jobs point at localhost:5432/devdb — edit jobs/*.yaml for your target).
+#   * DB_PASSWORD exported (used by both psql and SeedStream).
+#   * SeedStream on PATH, OR set SEEDSTREAM to the launcher. The Postgres JDBC driver must be dropped
+#     into the distribution's extras/ dir (drivers are not bundled — vendor-neutral by design; see
+#     docs/CONTAINER.md and PERFORMANCE.md).
+#
+# Row counts below are the parent-pool sizes. They MUST stay in sync with the static ref ranges in
+# structures/*.yaml (e.g. projects.owner_id = ref[users.id, 1..200] ⇔ users seeded with 200).
+set -euo pipefail
+
+: "${DB_PASSWORD:?export DB_PASSWORD first}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SEEDSTREAM="${SEEDSTREAM:-seedstream}"
+PGHOST="${PGHOST:-localhost}"
+PGPORT="${PGPORT:-5432}"
+PGUSER="${PGUSER:-devuser}"
+PGDATABASE="${PGDATABASE:-devdb}"
+
+echo "==> Creating schema"
+PGPASSWORD="$DB_PASSWORD" psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" \
+  -v ON_ERROR_STOP=1 -f "$DIR/schema.sql"
+
+seed() {  # seed <table> <count>
+  echo "==> Seeding $1 ($2 rows)"
+  "$SEEDSTREAM" execute --job "$DIR/jobs/db_$1.yaml" --count "$2"
+}
+
+# Parent-first: users/labels have no FKs; the rest reference earlier tables.
+seed users        200
+seed labels        20
+seed projects      50
+seed tasks        500
+seed comments    2000
+seed task_labels  800
+
+echo "==> Done. Populated task-tracker DB is ready."

--- a/use-cases/dev-env-bootstrapping/jobs/db_comments.yaml
+++ b/use-cases/dev-env-bootstrapping/jobs/db_comments.yaml
@@ -1,0 +1,13 @@
+# structures_path auto-resolves to ../structures/ (dir ends in "jobs").
+source: comments.yaml
+type: database
+seed:
+  type: embedded
+  value: 20260725          # fixed → every developer gets identical data
+conf:
+  jdbc_url: "jdbc:postgresql://localhost:5432/devdb"
+  username: "devuser"
+  password: "${DB_PASSWORD}"
+  table: "comments"
+  batch_size: 500
+  transaction_strategy: per_batch

--- a/use-cases/dev-env-bootstrapping/jobs/db_labels.yaml
+++ b/use-cases/dev-env-bootstrapping/jobs/db_labels.yaml
@@ -1,0 +1,13 @@
+# structures_path auto-resolves to ../structures/ (dir ends in "jobs").
+source: labels.yaml
+type: database
+seed:
+  type: embedded
+  value: 20260725          # fixed → every developer gets identical data
+conf:
+  jdbc_url: "jdbc:postgresql://localhost:5432/devdb"
+  username: "devuser"
+  password: "${DB_PASSWORD}"
+  table: "labels"
+  batch_size: 500
+  transaction_strategy: per_batch

--- a/use-cases/dev-env-bootstrapping/jobs/db_projects.yaml
+++ b/use-cases/dev-env-bootstrapping/jobs/db_projects.yaml
@@ -1,0 +1,13 @@
+# structures_path auto-resolves to ../structures/ (dir ends in "jobs").
+source: projects.yaml
+type: database
+seed:
+  type: embedded
+  value: 20260725          # fixed → every developer gets identical data
+conf:
+  jdbc_url: "jdbc:postgresql://localhost:5432/devdb"
+  username: "devuser"
+  password: "${DB_PASSWORD}"
+  table: "projects"
+  batch_size: 500
+  transaction_strategy: per_batch

--- a/use-cases/dev-env-bootstrapping/jobs/db_task_labels.yaml
+++ b/use-cases/dev-env-bootstrapping/jobs/db_task_labels.yaml
@@ -1,0 +1,13 @@
+# structures_path auto-resolves to ../structures/ (dir ends in "jobs").
+source: task_labels.yaml
+type: database
+seed:
+  type: embedded
+  value: 20260725          # fixed → every developer gets identical data
+conf:
+  jdbc_url: "jdbc:postgresql://localhost:5432/devdb"
+  username: "devuser"
+  password: "${DB_PASSWORD}"
+  table: "task_labels"
+  batch_size: 500
+  transaction_strategy: per_batch

--- a/use-cases/dev-env-bootstrapping/jobs/db_tasks.yaml
+++ b/use-cases/dev-env-bootstrapping/jobs/db_tasks.yaml
@@ -1,0 +1,13 @@
+# structures_path auto-resolves to ../structures/ (dir ends in "jobs").
+source: tasks.yaml
+type: database
+seed:
+  type: embedded
+  value: 20260725          # fixed → every developer gets identical data
+conf:
+  jdbc_url: "jdbc:postgresql://localhost:5432/devdb"
+  username: "devuser"
+  password: "${DB_PASSWORD}"
+  table: "tasks"
+  batch_size: 500
+  transaction_strategy: per_batch

--- a/use-cases/dev-env-bootstrapping/jobs/db_users.yaml
+++ b/use-cases/dev-env-bootstrapping/jobs/db_users.yaml
@@ -1,0 +1,13 @@
+# structures_path auto-resolves to ../structures/ (dir ends in "jobs").
+source: users.yaml
+type: database
+seed:
+  type: embedded
+  value: 20260725          # fixed → every developer gets identical data
+conf:
+  jdbc_url: "jdbc:postgresql://localhost:5432/devdb"
+  username: "devuser"
+  password: "${DB_PASSWORD}"
+  table: "users"
+  batch_size: 500
+  transaction_strategy: per_batch

--- a/use-cases/dev-env-bootstrapping/schema.sql
+++ b/use-cases/dev-env-bootstrapping/schema.sql
@@ -1,0 +1,54 @@
+-- Developer-environment bootstrap schema (issue #79) — a small but real task-tracker app.
+-- Surrogate PKs are DB-assigned IDENTITY columns: Postgres fills a dense 1..N sequence, so
+-- SeedStream does NOT generate `id` (the structures omit it). Child jobs then reference that
+-- dense pool with a static `ref[parent.id, 1..<parent_count>]`, and every FK resolves.
+--
+-- Run order matters (parents before children); bootstrap.sh handles it.
+-- Usage (once): PGPASSWORD=... psql -h localhost -U devuser -d devdb -f schema.sql
+
+DROP TABLE IF EXISTS task_labels, comments, tasks, projects, labels, users CASCADE;
+
+CREATE TABLE users (
+  id         BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  email      VARCHAR(255) NOT NULL,
+  full_name  VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP    NOT NULL
+);
+
+CREATE TABLE labels (
+  id   BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  name VARCHAR(40) NOT NULL
+);
+
+CREATE TABLE projects (
+  id       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  name     VARCHAR(120) NOT NULL,
+  status   VARCHAR(16)  NOT NULL CHECK (status IN ('active','archived','draft')),
+  owner_id BIGINT       NOT NULL REFERENCES users(id)
+);
+
+CREATE TABLE tasks (
+  id             BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  title          VARCHAR(200) NOT NULL,
+  status         VARCHAR(16)  NOT NULL CHECK (status IN ('todo','in_progress','done','blocked')),
+  priority       VARCHAR(8)   NOT NULL CHECK (priority IN ('low','med','high')),
+  project_id     BIGINT       NOT NULL REFERENCES projects(id),
+  assignee_id    BIGINT       NOT NULL REFERENCES users(id),
+  -- Self-referencing subtasks: column exists, but SeedStream leaves it NULL (see README "Limits").
+  parent_task_id BIGINT       REFERENCES tasks(id)
+);
+
+CREATE TABLE comments (
+  id        BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  body      VARCHAR(500) NOT NULL,
+  task_id   BIGINT       NOT NULL REFERENCES tasks(id),
+  author_id BIGINT       NOT NULL REFERENCES users(id)
+);
+
+-- Join table (M:N task↔label). Surrogate PK, no UNIQUE(task_id,label_id): with random refs a
+-- (task,label) pair can repeat. Add the UNIQUE constraint once a `unique` generator lands — see README.
+CREATE TABLE task_labels (
+  id       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  task_id  BIGINT NOT NULL REFERENCES tasks(id),
+  label_id BIGINT NOT NULL REFERENCES labels(id)
+);

--- a/use-cases/dev-env-bootstrapping/structures/comments.yaml
+++ b/use-cases/dev-env-bootstrapping/structures/comments.yaml
@@ -1,0 +1,8 @@
+name: comments
+data:
+  body:
+    datatype: char[10..500]
+  task_id:
+    datatype: ref[tasks.id, 1..500]
+  author_id:
+    datatype: ref[users.id, 1..200]

--- a/use-cases/dev-env-bootstrapping/structures/labels.yaml
+++ b/use-cases/dev-env-bootstrapping/structures/labels.yaml
@@ -1,0 +1,4 @@
+name: labels
+data:
+  name:
+    datatype: char[4..40]

--- a/use-cases/dev-env-bootstrapping/structures/projects.yaml
+++ b/use-cases/dev-env-bootstrapping/structures/projects.yaml
@@ -1,0 +1,10 @@
+# owner_id references the dense users pool. Static range MUST match the users --count in bootstrap.sh.
+name: projects
+geolocation: usa
+data:
+  name:
+    datatype: char[6..120]
+  status:
+    datatype: enum[active,archived,draft]
+  owner_id:
+    datatype: ref[users.id, 1..200]

--- a/use-cases/dev-env-bootstrapping/structures/task_labels.yaml
+++ b/use-cases/dev-env-bootstrapping/structures/task_labels.yaml
@@ -1,0 +1,7 @@
+# M:N join. No `id` (DB IDENTITY). A (task_id,label_id) pair may repeat — see README "Limits".
+name: task_labels
+data:
+  task_id:
+    datatype: ref[tasks.id, 1..500]
+  label_id:
+    datatype: ref[labels.id, 1..20]

--- a/use-cases/dev-env-bootstrapping/structures/tasks.yaml
+++ b/use-cases/dev-env-bootstrapping/structures/tasks.yaml
@@ -1,0 +1,15 @@
+# project_id/assignee_id reference the projects/users pools — ranges match bootstrap.sh counts.
+# parent_task_id is intentionally NOT generated (left NULL): self-referencing FKs need deferrable
+# constraints or an ordered pass SeedStream does not do today. See README "Limits".
+name: tasks
+data:
+  title:
+    datatype: char[10..200]
+  status:
+    datatype: enum[todo,in_progress,done,blocked]
+  priority:
+    datatype: enum[low,med,high]
+  project_id:
+    datatype: ref[projects.id, 1..50]
+  assignee_id:
+    datatype: ref[users.id, 1..200]

--- a/use-cases/dev-env-bootstrapping/structures/users.yaml
+++ b/use-cases/dev-env-bootstrapping/structures/users.yaml
@@ -1,0 +1,10 @@
+# users table. No `id` — the DB IDENTITY column assigns a dense 1..N sequence.
+name: users
+geolocation: usa
+data:
+  email:
+    datatype: email
+  full_name:
+    datatype: full_name
+  created_at:
+    datatype: timestamp[2023-01-01T00:00:00..2025-12-31T23:59:59]


### PR DESCRIPTION
## What
Self-contained use case for **#79**: one command seeds an empty Postgres with a realistic, fully linked task-tracker dataset (`users · projects · tasks · comments · labels · task_labels`) — no production dump, no PII.

## How integrity holds (no new engine features)
Uses the in-design, **stateless-generator** approach:
1. DB-assigned `IDENTITY` PKs → dense `1..N` pool; structures omit `id`.
2. Children reference that pool with static `ref[parent.id, 1..N]` ranges.
3. Seeded parent-first by `bootstrap.sh`.

**Verified end-to-end against Postgres with all FK constraints enabled: zero orphan rows** across the multi-parent (`tasks`, `comments`) and M:N (`task_labels`) edges; PKs dense `1..N`; `CHECK` enums honored.

## Contents
- `schema.sql` — 6 tables, IDENTITY PKs, FKs, CHECK enums
- `structures/*.yaml` ×6 — flat, no `id`, static-range `ref[]`
- `jobs/db_*.yaml` ×6 — one per table, fixed seed
- `bootstrap.sh` — schema + ordered seeding
- `README.md` — mechanism + honest limits
- flips the #79 row in `use-cases/README.md` to **Ready**

## Documented limits → tracked enhancements
- Repeatable M:N pairs → `unique` type (#212)
- NULL self-refs (`parent_task_id`) → self-ref FK support (#213)
- Manual post-inspect tuning → inspect `CHECK`→`enum` (#214), skip identity PKs (#215)

Docs-only (config/YAML/SQL/shell) — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)