### PR TITLE
chore(deps): batch 11 Dependabot bumps (#239-#250)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,7 +59,7 @@ jobs:
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,7 +117,7 @@ subprojects {
             // constraint) while runtimeClasspath correctly overrides to 2.22.0. 2.20.0 carries
             // CVE-2026-54512/54513 (CVSS > 7) + 54514; force the catalog version everywhere so
             // OWASP DC never sees 2.20.0 on any configuration.
-            "com.fasterxml.jackson.core:jackson-databind:2.22.1",
+            "com.fasterxml.jackson.core:jackson-databind:2.22.2",
             // httpclient5: AWS SDK apache5-client (:benchmarks) and Azure Key Vault secrets
             // (:schema) pull httpclient5 5.6.2, vulnerable to CVE-2026-71290 (CVSS 9.1 — async
             // TLS hostname verification silently disabled, HostnameVerificationPolicy#BUILTIN
@@ -153,7 +153,7 @@ subprojects {
 
         // Force newer versions to address security vulnerabilities
         constraints {
-            implementation("com.google.protobuf:protobuf-java:4.35.1") // CVE-2024-7254
+            implementation("com.google.protobuf:protobuf-java:4.36.0") // CVE-2024-7254
         }
 
         // Logging

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,10 +3,10 @@
 
 [versions]
 # Core Libraries
-jackson = "2.22.1"
+jackson = "2.22.2"
 lombok = "1.18.46"
 slf4j = "2.0.18"
-logback = "1.6.1"
+logback = "1.6.3"
 picocli = "4.7.7"
 
 # Data Generation
@@ -26,8 +26,8 @@ jsqlparser = "5.3"
 
 # I/O & Serialization
 opencsv = "5.12.0"
-protobuf = "4.35.1"  # Updated from 3.25.5 (major version upgrade)
-avro = "1.12.1"
+protobuf = "4.36.0"  # Updated from 3.25.5 (major version upgrade)
+avro = "1.12.2"
 
 # Messaging
 kafka = "4.3.1"
@@ -40,7 +40,7 @@ ojdbc = "23.26.3.0.0"
 mssql-jdbc = "13.4.0.jre11"
 
 # Testing
-junit = "6.1.2"
+junit = "6.1.3"
 h2 = "2.4.240"
 mockito = "5.21.0"
 assertj = "3.27.7"
@@ -48,8 +48,8 @@ testcontainers = "1.21.4"
 awaitility = "4.3.0"  # Updated from 4.2.2
 
 # Security
-aws-sdk = "2.51.2"
-azure-keyvault-secrets = "4.11.1"
+aws-sdk = "2.54.1"
+azure-keyvault-secrets = "4.11.2"
 azure-identity = "1.18.4"
 gcp-secretmanager = "2.95.0"
 
@@ -59,8 +59,8 @@ log4j = "2.26.1"
 # Build Plugins
 jmh-plugin = "0.7.3"
 lombok-plugin = "9.5.0"
-spotless-plugin = "8.9.0"
-spotbugs-plugin = "6.5.10"
+spotless-plugin = "8.10.0"
+spotbugs-plugin = "6.5.11"
 dependency-check-plugin = "13.0.0"
 sonarqube-plugin = "7.4.0.8496"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Compresses 11 open Dependabot PRs into a single CI cycle to conserve GitHub Actions minutes.

## Bumps

**Catalog** (`gradle/libs.versions.toml`)
| PR | Dependency | From → To |
|----|-----------|-----------|
| #250 | `org.apache.avro:avro` | 1.12.1 → 1.12.2 |
| #249 | `software.amazon.awssdk` (aws-sdk) | 2.51.2 → 2.54.1 |
| #247 | `com.github.spotbugs` plugin | 6.5.10 → 6.5.11 |
| #246 | `com.azure:azure-security-keyvault-secrets` | 4.11.1 → 4.11.2 |
| #244 | `com.google.protobuf:protobuf-java` | 4.35.1 → 4.36.0 |
| #243 | `com.diffplug.spotless` plugin | 8.9.0 → 8.10.0 |
| #242 | `jackson` | 2.22.1 → 2.22.2 |
| #240 | `org.junit:junit-bom` | 6.1.2 → 6.1.3 |
| #239 | `ch.qos.logback:logback-classic` | 1.6.1 → 1.6.3 |

**Coupling fixes** (`build.gradle.kts`) — both artifacts are pinned in the `resolutionStrategy.force` / `constraints` blocks and must track the catalog or they'd pin *below* it:
- `jackson-databind` force → 2.22.2
- `protobuf-java` constraint → 4.36.0

**Non-catalog**
- #248 gradle-wrapper 9.7.0 → 9.7.1
- #245 `docker/setup-buildx-action` 4.2.0 → 4.3.0 (pinned SHA)

## Security note

`aws-sdk` 2.54.1 and `azure-security-keyvault-secrets` 4.11.2 now pull **httpclient5 5.6.4** transitively (both `:benchmarks` and `:schema`), so this batch clears **CVE-2026-71290** / **CVE-2026-64607** on its own — the manual force in #251 becomes redundant once this merges.

## Verification
- `./gradlew build` green on gradle 9.7.1.
- `jackson-databind` resolves 2.22.2, `protobuf-java` 4.36.0 across configurations (coupling verified via `dependencyInsight`).
- `AwsSecretsManagerResolverIT` green on LocalStack (8/8) — validates the 3-minor aws-sdk jump.
- OWASP Dependency-Check dispatched on this branch (skipped on PR triggers by design).

Closes #239, #240, #242, #243, #244, #245, #246, #247, #248, #249, #250.