### PR TITLE
fix(security): force netty 4.1.137.Final for CVE-2026-62380

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -125,9 +125,12 @@ subprojects {
             // Both fixed in 5.6.4. Force everywhere so OWASP DC never sees 5.6.2 on any config.
             "org.apache.httpcomponents.client5:httpclient5:5.6.4"
         )
-        // netty ships ~20 coordinated artifacts, all pulled transitively at 4.1.135.Final via
-        // software.amazon.awssdk:netty-nio-client (awssdk 2.48.3 still resolves .135). 4.1.135 is
-        // vulnerable to CVE-2026-44891, CVE-2026-55831, CVE-2026-55833; 4.1.136.Final is the fix.
+        // netty ships ~20 coordinated artifacts, all pulled transitively via
+        // software.amazon.awssdk:netty-nio-client. 4.1.135.Final was vulnerable to
+        // CVE-2026-44891, CVE-2026-55831, CVE-2026-55833 (fixed in 4.1.136.Final);
+        // 4.1.136.Final is in turn vulnerable to CVE-2026-62380 (netty-codec-socks SOCKS4/5
+        // client encoder null-byte/CRLF/credential injection, CVSS >7.0), fixed in 4.1.137.Final.
+        // awssdk 2.54.1 already requests 4.1.137.Final; this force was actively downgrading it.
         // eachDependency force covers every io.netty artifact without listing each coordinate.
         resolutionStrategy.eachDependency {
             // tcnative (netty-tcnative*) and netty-bom follow their own versioning, not the
@@ -137,8 +140,8 @@ subprojects {
                 !requested.name.startsWith("netty-tcnative") &&
                 requested.name != "netty-bom"
             ) {
-                useVersion("4.1.136.Final")
-                because("CVE-2026-44891/55831/55833 — force patched netty across all configurations")
+                useVersion("4.1.137.Final")
+                because("CVE-2026-44891/55831/55833/62380 — force patched netty across all configurations")
             }
         }
     }


### PR DESCRIPTION
## Why
Nightly Security Scan started failing (run 33287946172): OWASP Dependency-Check flagged **CVE-2026-62380** (CVSS >7.0) against netty 4.1.136.Final in `:benchmarks`. Fresh NVD data — not triggered by any commit.

netty-codec-socks SOCKS4/5 client encoders in netty 4.1.x ≤ 4.1.136.Final allow null-byte / CRLF / credential injection → domain spoofing, auth-data injection. Fixed in **4.1.137.Final**.

## What
netty is transitive via `software.amazon.awssdk:netty-nio-client` (2.54.1), which already requests 4.1.137.Final. The existing `eachDependency` force was actively **downgrading** it to the vulnerable 4.1.136.Final. Bumped the force one patch:

- `useVersion("4.1.136.Final")` → `4.1.137.Final`
- All `io.netty:netty-*` artifacts now resolve to 4.1.137.Final (verified via dependency tree).
- `netty-tcnative` and `netty-bom` stay excluded from the force, as before.

## Verified locally
- Dependency resolution: every netty artifact → 4.1.137.Final
- `./gradlew build` (unit + spotless) ✅
- `./gradlew integrationTest` (Testcontainers e2e) ✅
- SonarQube quality gate: OK ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)