### PR TITLE
fix: 7 correctness/leak/determinism bugs from code review (#254-#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > machine's offset; re-run the job to normalise them. Values written on a UTC machine are unchanged,
 > as are `TIMESTAMP WITH TIME ZONE` columns.
 
+> ### ⚠️ `decimal` output changes for a given seed
+>
+> `decimal[min..max]` fields now draw from a discrete uniform grid so the upper bound `max` is
+> actually reachable (see *Changed*). This changes which value a given seed produces for **every**
+> `decimal` field. If you depend on byte-identical output across versions — golden files, recorded
+> fixtures, contract tests — regenerate them. Determinism *within* this version is unchanged: a
+> given seed still yields byte-identical output on any thread count.
+
+### Changed
+- **`decimal` generator now reaches its inclusive `max` (#260)** — the old algorithm was
+  `min + nextDouble() * (max - min)`, and `nextDouble()` returns `[0.0, 1.0)`, so `max` was
+  approached but never emitted; at higher scale (e.g. `decimal[0.000000..100.000000]`) it was
+  effectively unreachable, contradicting the documented inclusive-both-ends contract. The generator
+  now draws a uniform integer `k` in `[0, steps]` where `steps = (max - min) * 10^scale`, then maps
+  it to `min + k * 10^-scale` — so both `min` (k=0) and `max` (k=steps) are reachable and the
+  distribution is uniform over the representable grid. **Breaking:** output differs from prior
+  versions for the same seed on any `decimal` field. A pathological grid that overflows `long`
+  (`(max-min)*10^scale > ~9.2e18`) falls back to the old continuous interpolation.
+
 ### Fixed
+- **`IntegerGenerator` hung forever on `int` ranges wider than 2^31 (#254)** — the rejection-sampling
+  fallback computed `limit = 2^31 - (2^31 % range)`, which is `0` for any range in `(2^31, 2^32]`, so
+  the sampling loop never terminated. `int[-2000000000..2000000000]` and the full-width
+  `int[-2147483648..2147483647]` spun a CPU core indefinitely. Replaced with a single
+  `min + (int) nextLong(range)` draw that covers the full width uniformly.
+- **`timestamp` `now`-relative ranges were not reproducible (#255)** — `now`/`now±Nd` were re-resolved
+  against the moving wall clock on every record (no bounds cache), so a fixed seed drifted across
+  records within a run and between runs. Bounds are now snapshotted once per field (matching the
+  other primitive generators), freezing `now` at first touch.
+- **`StructureRegistry` cache was a non-thread-safe `HashMap` read/written on worker threads (#256)** —
+  `ObjectGenerator.generate()` calls `loadStructure()` from parallel workers; a concurrent first-load
+  of the same nested `object[...]` could corrupt the map (lost entries, resize infinite loop).
+  Switched to `ConcurrentHashMap`.
+- **Kafka producer leaked if the shutdown `flush()` threw (#257)** — `close()` ran `flush()` then
+  `producer.close()` in one `try` with no `finally`, so an unreachable broker at shutdown leaked the
+  producer's I/O thread and sockets. `producer.close()` now runs in a `finally`.
+- **Kafka async mode silently dropped failed records (#258)** — async send failures were only logged,
+  and `recordCount` counted submissions not acknowledgements, so a run reported success while fewer
+  than `N` records landed. Failures are now counted and surfaced as a `DestinationException` at
+  `close()`.
+- **Database/File destinations leaked resources after a partial `open()` (#259)** — `close()`
+  early-returned on `!isOpen`, but `open()` allocated the DataSource / file streams before setting
+  `isOpen`, so a failure part-way through `open()` was never cleaned up. `close()` now releases any
+  partially-allocated resources.
+- **`FakerCache` silently served a stale-seeded `Faker` instead of failing fast (#261)** — on a reused
+  thread handed a different `Random` without `FakerCache.clear()`, it logged a warning and kept the
+  first job's stale RNG, silently losing reproducibility. It now throws `IllegalStateException`.
 - **Database timestamps were bound in the JVM's default time zone (#80)** — `setTimestamp()` was called without a `Calendar`, so the driver rendered each `Instant` in the local zone before writing it to a `TIMESTAMP` column. The same seed therefore produced different stored wall-clock values on different machines: an instant of `12:00:00Z` landed as `14:00:00` on a CEST developer box and `12:00:00` on a UTC CI runner, breaking the cross-machine reproducibility guarantee for any structure with a `timestamp` field. Timestamps are now bound as a `LocalDateTime` taken at `ZoneOffset.UTC` — a value with no offset, so the driver has nothing to convert and the stored wall clock depends only on the seed. `date` fields were never affected. Verified on PostgreSQL, MySQL, Oracle and SQL Server. Caught by the new CI seeding use case, whose fingerprint differed between a local run and GitHub Actions. Note that zone-aware column types still apply their own conversion: PostgreSQL `timestamptz` and Oracle `TIMESTAMP WITH TIME ZONE` preserve the instant, but MySQL `TIMESTAMP` converts using the connection's session zone and can still drift (#218).
 
 ### Added

--- a/core/src/main/java/com/datagenerator/core/structure/StructureRegistry.java
+++ b/core/src/main/java/com/datagenerator/core/structure/StructureRegistry.java
@@ -23,16 +23,16 @@ import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Registry for loaded data structures with circular reference detection. Maintains a cache of
  * parsed structures and tracks loading stack to detect cycles.
  */
 public class StructureRegistry {
-  private final Map<String, Map<String, DataType>> structureCache = new HashMap<>();
+  private final Map<String, Map<String, DataType>> structureCache = new ConcurrentHashMap<>();
   private final StructureLoader loader;
   private final ThreadLocal<Deque<String>> loadingStack = ThreadLocal.withInitial(ArrayDeque::new);
 

--- a/core/src/test/java/com/datagenerator/core/structure/StructureRegistryTest.java
+++ b/core/src/test/java/com/datagenerator/core/structure/StructureRegistryTest.java
@@ -24,13 +24,14 @@ import com.datagenerator.core.type.DataType;
 import com.datagenerator.core.type.ObjectType;
 import com.datagenerator.core.type.PrimitiveType;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -157,7 +158,7 @@ class StructureRegistryTest {
   }
 
   @Test
-  void shouldHandleConcurrentLoadsOfSameStructureSafely() throws InterruptedException {
+  void shouldHandleConcurrentLoadsOfSameStructureSafely() throws Exception {
     // Regression for issue #256: structureCache was a plain HashMap, unsafe for concurrent
     // put/get from multiple worker threads loading the same not-yet-cached structure.
     Map<String, DataType> fields = new HashMap<>();
@@ -167,34 +168,30 @@ class StructureRegistryTest {
     int threadCount = 16;
     ExecutorService executor = Executors.newFixedThreadPool(threadCount);
     CountDownLatch startLatch = new CountDownLatch(1);
-    CountDownLatch doneLatch = new CountDownLatch(threadCount);
-    List<Map<String, DataType>> results = new CopyOnWriteArrayList<>();
-    List<Throwable> errors = new CopyOnWriteArrayList<>();
-
     var structuresPath = Path.of(CONFIG_STRUCTURES);
+
+    List<Future<Map<String, DataType>>> futures = new ArrayList<>();
     for (int i = 0; i < threadCount; i++) {
-      executor.submit(
-          () -> {
-            try {
-              startLatch.await();
-              results.add(registry.loadStructure("concurrent_struct", structuresPath));
-            } catch (InterruptedException e) {
-              Thread.currentThread().interrupt();
-              errors.add(e);
-            } catch (RuntimeException e) {
-              errors.add(e);
-            } finally {
-              doneLatch.countDown();
-            }
-          });
+      futures.add(
+          executor.submit(
+              () -> {
+                startLatch.await();
+                return registry.loadStructure("concurrent_struct", structuresPath);
+              }));
     }
 
+    // Release all threads at once to maximise the chance of a concurrent first-load race.
     startLatch.countDown();
-    assertThat(doneLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+    List<Map<String, DataType>> results = new ArrayList<>();
+    for (Future<Map<String, DataType>> future : futures) {
+      // get() surfaces any exception thrown on a worker thread as ExecutionException — a corrupted
+      // cache or a failed load therefore fails the test right here.
+      results.add(future.get(10, TimeUnit.SECONDS));
+    }
     executor.shutdown();
     assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
 
-    assertThat(errors).isEmpty();
     assertThat(results).hasSize(threadCount);
     assertThat(results).allSatisfy(r -> assertThat(r).isEqualTo(results.get(0)));
   }

--- a/core/src/test/java/com/datagenerator/core/structure/StructureRegistryTest.java
+++ b/core/src/test/java/com/datagenerator/core/structure/StructureRegistryTest.java
@@ -25,7 +25,13 @@ import com.datagenerator.core.type.ObjectType;
 import com.datagenerator.core.type.PrimitiveType;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -148,6 +154,46 @@ class StructureRegistryTest {
 
     registry.validateReferences(loaded, Path.of(CONFIG_STRUCTURES));
     // Should complete without exception
+  }
+
+  @Test
+  void shouldHandleConcurrentLoadsOfSameStructureSafely() throws InterruptedException {
+    // Regression for issue #256: structureCache was a plain HashMap, unsafe for concurrent
+    // put/get from multiple worker threads loading the same not-yet-cached structure.
+    Map<String, DataType> fields = new HashMap<>();
+    fields.put("id", new PrimitiveType(PrimitiveType.Kind.INT, "1", "999"));
+    loader.addStructure("concurrent_struct", fields);
+
+    int threadCount = 16;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(threadCount);
+    List<Map<String, DataType>> results = new CopyOnWriteArrayList<>();
+    List<Throwable> errors = new CopyOnWriteArrayList<>();
+
+    var structuresPath = Path.of(CONFIG_STRUCTURES);
+    for (int i = 0; i < threadCount; i++) {
+      executor.submit(
+          () -> {
+            try {
+              startLatch.await();
+              results.add(registry.loadStructure("concurrent_struct", structuresPath));
+            } catch (Exception e) {
+              errors.add(e);
+            } finally {
+              doneLatch.countDown();
+            }
+          });
+    }
+
+    startLatch.countDown();
+    assertThat(doneLatch.await(10, TimeUnit.SECONDS)).isTrue();
+    executor.shutdown();
+    assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+
+    assertThat(errors).isEmpty();
+    assertThat(results).hasSize(threadCount);
+    assertThat(results).allSatisfy(r -> assertThat(r).isEqualTo(results.get(0)));
   }
 
   /** Mock loader for testing */

--- a/core/src/test/java/com/datagenerator/core/structure/StructureRegistryTest.java
+++ b/core/src/test/java/com/datagenerator/core/structure/StructureRegistryTest.java
@@ -178,7 +178,10 @@ class StructureRegistryTest {
             try {
               startLatch.await();
               results.add(registry.loadStructure("concurrent_struct", structuresPath));
-            } catch (Exception e) {
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              errors.add(e);
+            } catch (RuntimeException e) {
               errors.add(e);
             } finally {
               doneLatch.countDown();

--- a/destinations/src/main/java/com/datagenerator/destinations/database/DatabaseDestination.java
+++ b/destinations/src/main/java/com/datagenerator/destinations/database/DatabaseDestination.java
@@ -312,6 +312,9 @@ public class DatabaseDestination extends AbstractDestination {
   public void close() {
     if (!isOpen) {
       log.debug("Database destination already closed");
+      // open() may have allocated a connection/pool before failing prior to setting isOpen —
+      // release any such partially-opened resources. closeQuietly() is null-safe.
+      closeQuietly();
       return;
     }
 

--- a/destinations/src/main/java/com/datagenerator/destinations/file/FileDestination.java
+++ b/destinations/src/main/java/com/datagenerator/destinations/file/FileDestination.java
@@ -351,6 +351,9 @@ public class FileDestination extends AbstractDestination {
   public void close() {
     if (!isOpen) {
       log.debug("File destination already closed: {}", config.getFilePath());
+      // open() may have allocated a stream before failing prior to setting isOpen — release any
+      // such partially-opened resources.
+      closeQuietly();
       return;
     }
 
@@ -374,6 +377,36 @@ public class FileDestination extends AbstractDestination {
       log.info("Closed file destination: {}", config.getFilePath());
     } catch (IOException e) {
       throw new DestinationException("Failed to close file", e);
+    }
+  }
+
+  /**
+   * Best-effort, null-safe cleanup of any resources {@link #open()} may have allocated before
+   * failing partway through (i.e. before {@code isOpen} was set to {@code true}). Never throws.
+   */
+  private void closeQuietly() {
+    try {
+      if (streamWriter != null) {
+        streamWriter.close();
+      }
+    } catch (IOException e) {
+      log.warn("Failed to close StreamWriter during cleanup", e);
+    }
+    try {
+      if (outputStream != null) {
+        outputStream.close();
+      }
+    } catch (IOException e) {
+      log.warn("Failed to close OutputStream during cleanup", e);
+    }
+    try {
+      if (avroFileWriter != null) {
+        avroFileWriter.close(); // also closes avroRawOut
+      } else if (avroRawOut != null) {
+        avroRawOut.close();
+      }
+    } catch (IOException e) {
+      log.warn("Failed to close Avro writer during cleanup", e);
     }
   }
 

--- a/destinations/src/main/java/com/datagenerator/destinations/kafka/KafkaDestination.java
+++ b/destinations/src/main/java/com/datagenerator/destinations/kafka/KafkaDestination.java
@@ -24,6 +24,7 @@ import com.datagenerator.formats.FormatSerializer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
@@ -75,7 +76,10 @@ public class KafkaDestination extends AbstractDestination {
   private final RetryPolicy retryPolicy;
 
   private Producer<String, byte[]> producer;
-  private long recordCount = 0;
+  // AtomicLong: the producer is documented thread-safe for concurrent workers, and this class
+  // is also touched from the Kafka I/O thread via the async send callback below.
+  private final AtomicLong recordCount = new AtomicLong();
+  private final AtomicLong asyncFailures = new AtomicLong();
 
   /**
    * Create Kafka destination with configuration and serializer.
@@ -218,6 +222,7 @@ public class KafkaDestination extends AbstractDestination {
             (metadata, exception) -> {
               if (exception != null) {
                 log.error("Failed to send record to Kafka topic: {}", config.getTopic(), exception);
+                asyncFailures.incrementAndGet();
               } else {
                 // TRACE log successful send (sampled)
                 if (log.isTraceEnabled() && LogUtils.shouldTrace()) {
@@ -230,11 +235,11 @@ public class KafkaDestination extends AbstractDestination {
             });
       }
 
-      recordCount++;
+      long count = recordCount.incrementAndGet();
 
       // Progress logging every 10,000 records
-      if (recordCount % 10000 == 0) {
-        log.info("Sent {} records to Kafka topic: {}", recordCount, config.getTopic());
+      if (count % 10000 == 0) {
+        log.info("Sent {} records to Kafka topic: {}", count, config.getTopic());
       }
 
     } catch (DestinationException e) {
@@ -264,10 +269,22 @@ public class KafkaDestination extends AbstractDestination {
     }
 
     try {
-      flush();
-      producer.close();
-      isOpen = false;
-      log.info("Closed Kafka destination - total records sent: {}", recordCount);
+      try {
+        flush();
+      } finally {
+        // flush() blocks until all async callbacks have fired, so asyncFailures is final here.
+        producer.close();
+        isOpen = false;
+      }
+      log.info("Closed Kafka destination - total records sent: {}", recordCount.get());
+
+      long failures = asyncFailures.get();
+      if (failures > 0) {
+        throw new DestinationException(
+            failures + " record(s) failed to send to Kafka topic " + config.getTopic());
+      }
+    } catch (DestinationException e) {
+      throw e;
     } catch (Exception e) {
       log.error("Error closing Kafka producer", e);
       throw new DestinationException("Failed to close Kafka producer", e);

--- a/destinations/src/test/java/com/datagenerator/destinations/kafka/KafkaDestinationTest.java
+++ b/destinations/src/test/java/com/datagenerator/destinations/kafka/KafkaDestinationTest.java
@@ -19,6 +19,8 @@ package com.datagenerator.destinations.kafka;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -29,6 +31,7 @@ import com.datagenerator.formats.json.JsonSerializer;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.junit.jupiter.api.Test;
@@ -250,6 +253,54 @@ class KafkaDestinationTest {
         .hasMessageContaining("failed after 2 attempt");
 
     verify(mockProducer, times(2)).send(any());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldSurfaceAsyncSendFailuresOnClose() {
+    // Regression for issue #258: async sends that fail in the Kafka callback were only logged,
+    // never surfaced to the caller — close() must now fail loudly instead of silently dropping
+    // records.
+    Producer<String, byte[]> mockProducer = mock(Producer.class);
+    doAnswer(
+            invocation -> {
+              Callback callback = invocation.getArgument(1);
+              callback.onCompletion(null, new RuntimeException("broker down"));
+              return null;
+            })
+        .when(mockProducer)
+        .send(any(), any(Callback.class));
+
+    KafkaDestinationConfig config =
+        KafkaDestinationConfig.builder().bootstrap(BOOTSTRAP).topic(TOPIC).sync(false).build();
+
+    KafkaDestination dest = new KafkaDestination(config, new JsonSerializer(), mockProducer);
+    dest.write(Map.of("key", "value"));
+
+    assertThatThrownBy(dest::close)
+        .isInstanceOf(DestinationException.class)
+        .hasMessageContaining("1 record(s) failed to send to Kafka topic " + TOPIC);
+
+    // Regression for issue #257: the producer must still be closed even though the failure
+    // check (raised after flush()) surfaces as an exception.
+    verify(mockProducer, times(1)).close();
+  }
+
+  @Test
+  void shouldStillCloseProducerWhenFlushThrows() {
+    // Regression for issue #257: producer.close() must run even when flush() throws, so the
+    // producer/network resources aren't leaked.
+    Producer<String, byte[]> mockProducer = mock(Producer.class);
+    doThrow(new RuntimeException("flush boom")).when(mockProducer).flush();
+
+    KafkaDestinationConfig config =
+        KafkaDestinationConfig.builder().bootstrap(BOOTSTRAP).topic(TOPIC).build();
+
+    KafkaDestination dest = new KafkaDestination(config, new JsonSerializer(), mockProducer);
+
+    assertThatThrownBy(dest::close).isInstanceOf(DestinationException.class);
+
+    verify(mockProducer, times(1)).close();
   }
 
   // Note: Integration tests with actual Kafka broker using Testcontainers

--- a/generators/src/main/java/com/datagenerator/generators/primitive/DecimalGenerator.java
+++ b/generators/src/main/java/com/datagenerator/generators/primitive/DecimalGenerator.java
@@ -22,6 +22,7 @@ import com.datagenerator.generators.DataGenerator;
 import com.datagenerator.generators.GeneratorException;
 import com.datagenerator.generators.GeneratorValidation;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.util.Map;
 import java.util.Random;
@@ -30,20 +31,19 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Generates random decimal numbers (decimal[min..max]) within specified bounds.
  *
- * <p><b>Algorithm:</b> Linear interpolation with random factor:
- *
- * <pre>
- * value = min + random.nextDouble() * (max - min)
- * </pre>
+ * <p><b>Algorithm:</b> Discrete uniform draw over the grid of representable values at the field's
+ * scale. With {@code steps = (max - min) * 10^scale}, a uniform integer {@code k in [0, steps]} is
+ * drawn and mapped to {@code min + k * 10^-scale}. This makes <b>both</b> {@code min} (k=0) and
+ * {@code max} (k=steps) reachable, unlike a {@code nextDouble()} interpolation whose {@code [0,1)}
+ * factor can never hit the upper bound.
  *
  * <p><b>Precision:</b> Returns BigDecimal with scale determined by max precision in min/max values.
- * Rounds HALF_UP to avoid floating-point errors.
  *
  * <p><b>Range:</b> Inclusive on both ends [min, max].
  */
 public class DecimalGenerator implements DataGenerator {
 
-  private record Bounds(BigDecimal min, BigDecimal range, int scale) {}
+  private record Bounds(BigDecimal min, BigDecimal range, int scale, BigInteger steps) {}
 
   private final Map<PrimitiveType, Bounds> boundsCache = new ConcurrentHashMap<>();
 
@@ -55,13 +55,23 @@ public class DecimalGenerator implements DataGenerator {
 
     Bounds b = boundsCache.computeIfAbsent(primitiveType, this::parseBounds);
 
-    // Generate random value: min + random * (max - min)
-    // nextDouble() returns [0.0, 1.0) so max is approached but not guaranteed; acceptable for
-    // decimals
-    BigDecimal randomFactor = BigDecimal.valueOf(random.nextDouble());
-    BigDecimal value = b.min().add(b.range().multiply(randomFactor));
+    BigInteger steps = b.steps();
+    BigDecimal value;
+    if (steps.signum() == 0) {
+      // min == max: the only representable value is min itself.
+      value = b.min();
+    } else if (steps.bitLength() < 63) {
+      // Common path: the grid fits in a long. Draw a uniform integer k in [0, steps] (inclusive)
+      // so both min (k=0) and max (k=steps) are reachable, then map back to the decimal grid.
+      long k = random.nextLong(steps.longValueExact() + 1);
+      value = b.min().add(BigDecimal.valueOf(k).movePointLeft(b.scale()));
+    } else {
+      // Pathological: (max-min)*10^scale exceeds long range. Fall back to continuous interpolation
+      // (upper bound then only approached, not guaranteed) rather than allocate a BigInteger draw.
+      BigDecimal randomFactor = BigDecimal.valueOf(random.nextDouble());
+      value = b.min().add(b.range().multiply(randomFactor));
+    }
 
-    // Round to desired scale
     return value.setScale(b.scale(), RoundingMode.HALF_UP);
   }
 
@@ -71,7 +81,10 @@ public class DecimalGenerator implements DataGenerator {
     GeneratorValidation.requireValidRange(min, max, "decimal");
     int scale = Math.max(min.scale(), max.scale());
     BigDecimal range = max.subtract(min);
-    return new Bounds(min, range, scale);
+    // Number of discrete increments of 10^-scale between min and max (exact: range's scale <=
+    // scale).
+    BigInteger steps = range.movePointRight(scale).toBigIntegerExact();
+    return new Bounds(min, range, scale, steps);
   }
 
   @Override

--- a/generators/src/main/java/com/datagenerator/generators/primitive/IntegerGenerator.java
+++ b/generators/src/main/java/com/datagenerator/generators/primitive/IntegerGenerator.java
@@ -21,6 +21,7 @@ import com.datagenerator.core.type.PrimitiveType;
 import com.datagenerator.generators.DataGenerator;
 import com.datagenerator.generators.GeneratorException;
 import com.datagenerator.generators.GeneratorValidation;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,6 +45,15 @@ public class IntegerGenerator implements DataGenerator {
 
   private final Map<PrimitiveType, Bounds> boundsCache = new ConcurrentHashMap<>();
 
+  @SuppressFBWarnings(
+      value = "RV_01_TO_INT",
+      justification =
+          "Not the Math.random()*n truncation bug this pattern targets: range here spans up to "
+              + "2^32 (min=Integer.MIN_VALUE, max=Integer.MAX_VALUE), so nextLong(range) can "
+              + "return any value in the full unsigned 32-bit space. Casting that to int "
+              + "reinterprets the low 32 bits as two's-complement, and adding b.min() with "
+              + "intentional int-overflow wraparound correctly enumerates the full [min,max] "
+              + "range uniformly.")
   @Override
   public Object generate(Random random, DataType dataType) {
     PrimitiveType primitiveType =
@@ -56,15 +66,10 @@ public class IntegerGenerator implements DataGenerator {
     // Use long arithmetic to avoid overflow when (max - min + 1) doesn't fit in int
     long range = (long) b.max() - b.min() + 1;
     if (range <= 0 || range > Integer.MAX_VALUE) {
-      // Range exceeds int capacity — rejection sampling for uniform distribution
-      int result;
-      long limit = (long) Integer.MAX_VALUE + 1 - ((long) Integer.MAX_VALUE + 1) % range;
-      do {
-        result = random.nextInt() & Integer.MAX_VALUE;
-      } while (result >= limit);
-      return b.min() + (int) (result % range);
+      // range spans more than the positive int space; nextLong(bound) samples uniformly in
+      // [0,range)
+      return b.min() + (int) random.nextLong(range);
     }
-
     return b.min() + random.nextInt((int) range);
   }
 

--- a/generators/src/main/java/com/datagenerator/generators/primitive/TimestampGenerator.java
+++ b/generators/src/main/java/com/datagenerator/generators/primitive/TimestampGenerator.java
@@ -27,7 +27,9 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -58,17 +60,21 @@ public class TimestampGenerator implements DataGenerator {
   private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
   private static final Pattern RELATIVE_PATTERN = Pattern.compile("now([+-])(\\d+)([dhms])");
 
+  private record Bounds(Instant start, Instant end) {}
+
+  private final Map<PrimitiveType, Bounds> boundsCache = new ConcurrentHashMap<>();
+
   @Override
   public Object generate(Random random, DataType dataType) {
     PrimitiveType primitiveType =
         GeneratorValidation.requirePrimitiveKind(
             dataType, PrimitiveType.Kind.TIMESTAMP, "TimestampGenerator");
 
-    // Parse start/end timestamps
-    Instant startTimestamp = parseTimestamp(primitiveType.getMinValue(), "minValue");
-    Instant endTimestamp = parseTimestamp(primitiveType.getMaxValue(), "maxValue");
-
-    GeneratorValidation.requireValidRange(startTimestamp, endTimestamp, "timestamp");
+    // Resolve start/end once per field — freezes "now" at first touch so the range doesn't
+    // drift across the many records generated for a single run.
+    Bounds bounds = boundsCache.computeIfAbsent(primitiveType, this::parseBounds);
+    Instant startTimestamp = bounds.start();
+    Instant endTimestamp = bounds.end();
 
     // Calculate seconds between timestamps
     long secondsBetween = ChronoUnit.SECONDS.between(startTimestamp, endTimestamp);
@@ -81,6 +87,13 @@ public class TimestampGenerator implements DataGenerator {
     long randomSeconds = random.nextLong(secondsBetween + 1);
 
     return startTimestamp.plusSeconds(randomSeconds);
+  }
+
+  private Bounds parseBounds(PrimitiveType primitiveType) {
+    Instant startTimestamp = parseTimestamp(primitiveType.getMinValue(), "minValue");
+    Instant endTimestamp = parseTimestamp(primitiveType.getMaxValue(), "maxValue");
+    GeneratorValidation.requireValidRange(startTimestamp, endTimestamp, "timestamp");
+    return new Bounds(startTimestamp, endTimestamp);
   }
 
   @Override

--- a/generators/src/main/java/com/datagenerator/generators/primitive/TimestampGenerator.java
+++ b/generators/src/main/java/com/datagenerator/generators/primitive/TimestampGenerator.java
@@ -102,6 +102,17 @@ public class TimestampGenerator implements DataGenerator {
         && primitiveType.getKind() == PrimitiveType.Kind.TIMESTAMP;
   }
 
+  /**
+   * Visible for testing: number of distinct fields whose {@code [start,end]} bounds have been
+   * resolved and cached. A cached field resolves {@code now} exactly once, so this is how the
+   * reproducibility fix (#255) is asserted without reflection.
+   *
+   * @return the number of cached bounds entries
+   */
+  int boundsCacheSize() {
+    return boundsCache.size();
+  }
+
   private Instant parseTimestamp(String value, String fieldName) {
     if (value == null) {
       throw new GeneratorException(

--- a/generators/src/main/java/com/datagenerator/generators/semantic/FakerCache.java
+++ b/generators/src/main/java/com/datagenerator/generators/semantic/FakerCache.java
@@ -96,13 +96,12 @@ public class FakerCache {
       THREAD_RANDOM.set(random);
       log.debug("Initialized FakerCache for thread: {}", Thread.currentThread().getName());
     } else if (storedRandom != random) {
-      // This should NEVER happen with RandomProvider (thread-local Random)
-      // But catch it to prevent subtle bugs if API is misused
-      log.warn(
-          "FakerCache detected different Random instance in thread {}. "
-              + "This breaks determinism! Expected same thread-local Random from RandomProvider.",
-          Thread.currentThread().getName());
-      // Use the first Random to maintain consistency
+      // This should NEVER happen with RandomProvider (thread-local Random). Serving the stale
+      // Faker here would silently break determinism, so fail fast instead.
+      throw new IllegalStateException(
+          "FakerCache received a different Random for an already-cached thread/locale; the "
+              + "thread-local Faker's seed is stale. Call FakerCache.clear() between jobs on a "
+              + "reused thread.");
     }
 
     Map<Locale, Faker> cache = CACHE.get();

--- a/generators/src/test/java/com/datagenerator/generators/primitive/DecimalGeneratorTest.java
+++ b/generators/src/test/java/com/datagenerator/generators/primitive/DecimalGeneratorTest.java
@@ -52,6 +52,31 @@ class DecimalGeneratorTest {
   }
 
   @Test
+  void shouldReachBothInclusiveBounds() {
+    // Small grid (0.0, 0.1, 0.2) so both endpoints are hit within a modest number of draws.
+    PrimitiveType type = new PrimitiveType(PrimitiveType.Kind.DECIMAL, "0.0", "0.2");
+    Random random = new Random(7L);
+    BigDecimal min = new BigDecimal("0.0");
+    BigDecimal max = new BigDecimal("0.2");
+
+    boolean hitMin = false;
+    boolean hitMax = false;
+    for (int i = 0; i < 500; i++) {
+      BigDecimal value = (BigDecimal) generator.generate(random, type);
+      assertThat(value).isBetween(min, max);
+      if (value.compareTo(min) == 0) {
+        hitMin = true;
+      }
+      if (value.compareTo(max) == 0) {
+        hitMax = true;
+      }
+    }
+
+    assertThat(hitMax).as("inclusive max (0.2) must be reachable").isTrue();
+    assertThat(hitMin).as("inclusive min (0.0) must be reachable").isTrue();
+  }
+
+  @Test
   void shouldPreserveScaleFromMaxPrecision() {
     PrimitiveType type = new PrimitiveType(PrimitiveType.Kind.DECIMAL, "0.00", "100.000");
     Random random = new Random(42L);

--- a/generators/src/test/java/com/datagenerator/generators/primitive/IntegerGeneratorTest.java
+++ b/generators/src/test/java/com/datagenerator/generators/primitive/IntegerGeneratorTest.java
@@ -120,6 +120,35 @@ class IntegerGeneratorTest {
   }
 
   @Test
+  void shouldTerminateQuicklyForFullIntRange() {
+    // Regression for issue #254: range = 2^32 (min=MIN_VALUE, max=MAX_VALUE) previously computed
+    // limit=0 in the rejection-sampling loop and spun forever. Must complete promptly.
+    PrimitiveType type =
+        new PrimitiveType(
+            PrimitiveType.Kind.INT,
+            String.valueOf(Integer.MIN_VALUE),
+            String.valueOf(Integer.MAX_VALUE));
+    Random random = new Random(42L);
+
+    for (int i = 0; i < 1000; i++) {
+      int value = (int) generator.generate(random, type);
+      assertThat(value).isBetween(Integer.MIN_VALUE, Integer.MAX_VALUE);
+    }
+  }
+
+  @Test
+  void shouldTerminateQuicklyForRangeJustOverIntCapacity() {
+    // Regression for issue #254: any range in (2^31, 2^32] hit the broken branch.
+    PrimitiveType type = new PrimitiveType(PrimitiveType.Kind.INT, "-2000000000", "2000000000");
+    Random random = new Random(42L);
+
+    for (int i = 0; i < 1000; i++) {
+      int value = (int) generator.generate(random, type);
+      assertThat(value).isBetween(-2000000000, 2000000000);
+    }
+  }
+
+  @Test
   void shouldSupportIntType() {
     PrimitiveType intType = new PrimitiveType(PrimitiveType.Kind.INT, "1", "10");
     PrimitiveType charType = new PrimitiveType(PrimitiveType.Kind.CHAR, "1", "10");

--- a/generators/src/test/java/com/datagenerator/generators/primitive/TimestampGeneratorTest.java
+++ b/generators/src/test/java/com/datagenerator/generators/primitive/TimestampGeneratorTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.*;
 import com.datagenerator.core.type.PrimitiveType;
 import com.datagenerator.generators.GeneratorException;
 import java.time.Instant;
+import java.util.Map;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
@@ -83,6 +84,28 @@ class TimestampGeneratorTest {
 
     Instant result = (Instant) generator.generate(new Random(1L), type);
     assertThat(result).isBeforeOrEqualTo(Instant.now());
+  }
+
+  @Test
+  void shouldFreezeNowBoundsAcrossRepeatedGenerateCalls() throws Exception {
+    // Regression for issue #255: "now" was re-resolved (via parseTimestamp -> Instant.now()) on
+    // EVERY generate() call, so successive records for the same field could observe subtly
+    // different [start,end] windows as wall-clock time advanced during a run. The fix caches
+    // resolved Bounds per PrimitiveType so "now" is frozen at first touch.
+    PrimitiveType type = new PrimitiveType(PrimitiveType.Kind.TIMESTAMP, "now-30d", "now");
+    Random random = new Random(7L);
+
+    for (int i = 0; i < 50; i++) {
+      generator.generate(random, type);
+    }
+
+    // Exactly one Bounds entry must exist for this field, no matter how many times generate()
+    // was called — i.e. the start/end were resolved once, not on every call.
+    var boundsCacheField = TimestampGenerator.class.getDeclaredField("boundsCache");
+    boundsCacheField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Map<Object, Object> boundsCache = (Map<Object, Object>) boundsCacheField.get(generator);
+    assertThat(boundsCache).hasSize(1).containsKey(type);
   }
 
   @Test

--- a/generators/src/test/java/com/datagenerator/generators/primitive/TimestampGeneratorTest.java
+++ b/generators/src/test/java/com/datagenerator/generators/primitive/TimestampGeneratorTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.*;
 import com.datagenerator.core.type.PrimitiveType;
 import com.datagenerator.generators.GeneratorException;
 import java.time.Instant;
-import java.util.Map;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
@@ -87,7 +86,7 @@ class TimestampGeneratorTest {
   }
 
   @Test
-  void shouldFreezeNowBoundsAcrossRepeatedGenerateCalls() throws Exception {
+  void shouldFreezeNowBoundsAcrossRepeatedGenerateCalls() {
     // Regression for issue #255: "now" was re-resolved (via parseTimestamp -> Instant.now()) on
     // EVERY generate() call, so successive records for the same field could observe subtly
     // different [start,end] windows as wall-clock time advanced during a run. The fix caches
@@ -101,11 +100,7 @@ class TimestampGeneratorTest {
 
     // Exactly one Bounds entry must exist for this field, no matter how many times generate()
     // was called — i.e. the start/end were resolved once, not on every call.
-    var boundsCacheField = TimestampGenerator.class.getDeclaredField("boundsCache");
-    boundsCacheField.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    Map<Object, Object> boundsCache = (Map<Object, Object>) boundsCacheField.get(generator);
-    assertThat(boundsCache).hasSize(1).containsKey(type);
+    assertThat(generator.boundsCacheSize()).isEqualTo(1);
   }
 
   @Test

--- a/generators/src/test/java/com/datagenerator/generators/semantic/DatafakerComplexStructureTest.java
+++ b/generators/src/test/java/com/datagenerator/generators/semantic/DatafakerComplexStructureTest.java
@@ -228,6 +228,9 @@ class DatafakerComplexStructureTest {
     String[] countries = {"italy", "germany", "france", "japan", "brazil"};
 
     for (String country : countries) {
+      // Each iteration builds a fresh Random on this thread — the FakerCache requires clearing
+      // first, or it fails fast on the stale-Random mismatch (see FakerCache).
+      FakerCache.clear();
       try (var ctx = GeneratorContext.enter(factory, country)) {
         Random random = new Random(12345L);
         Map<String, Object> passport =
@@ -301,6 +304,8 @@ class DatafakerComplexStructureTest {
     try (var ctx = GeneratorContext.enter(factory, "usa")) {
       // Generate 5 transactions with different seeds
       for (int i = 0; i < 5; i++) {
+        // Each iteration builds a fresh Random on this thread — clear first (see FakerCache).
+        FakerCache.clear();
         Random random = new Random(i);
         Map<String, Object> transaction =
             (Map<String, Object>) generator.generate(random, transactionType);
@@ -371,6 +376,8 @@ class DatafakerComplexStructureTest {
     try (var ctx = GeneratorContext.enter(factory, "usa")) {
       // Generate 5 movements with different seeds
       for (int i = 0; i < 5; i++) {
+        // Each iteration builds a fresh Random on this thread — clear first (see FakerCache).
+        FakerCache.clear();
         Random random = new Random((long) i * 1000);
         Map<String, Object> movement =
             (Map<String, Object>) generator.generate(random, movementType);
@@ -437,6 +444,8 @@ class DatafakerComplexStructureTest {
     String[] locales = {"usa", "italy", "germany", "france", "japan"};
 
     for (String locale : locales) {
+      // Each iteration builds a fresh Random on this thread — clear first (see FakerCache).
+      FakerCache.clear();
       try (var ctx = GeneratorContext.enter(factory, locale)) {
         Random random = new Random(12345L);
         Map<String, Object> transaction =

--- a/generators/src/test/java/com/datagenerator/generators/semantic/DatafakerGeneratorTest.java
+++ b/generators/src/test/java/com/datagenerator/generators/semantic/DatafakerGeneratorTest.java
@@ -233,6 +233,9 @@ class DatafakerGeneratorTest {
 
     try (var ctx = GeneratorContext.enter(factory, ITALY)) {
       String name1 = (String) generator.generate(random1, nameType);
+      // FakerCache requires the same thread-local Random for every call on a thread; switching
+      // to a different Random instance requires clearing the cache first (see FakerCache).
+      FakerCache.clear();
       String name2 = (String) generator.generate(random2, nameType);
 
       // Different seeds should produce different names (with very high probability)
@@ -249,6 +252,8 @@ class DatafakerGeneratorTest {
       assertThat(italianName).isNotNull();
     }
 
+    // Switching to a different Random instance on this thread requires clearing the cache first.
+    FakerCache.clear();
     Random newRandom = new Random(12345L);
     try (var ctx = GeneratorContext.enter(factory, "japan")) {
       String japaneseName = (String) generator.generate(newRandom, nameType);

--- a/generators/src/test/java/com/datagenerator/generators/semantic/DatafakerGeolocationTest.java
+++ b/generators/src/test/java/com/datagenerator/generators/semantic/DatafakerGeolocationTest.java
@@ -395,6 +395,8 @@ class DatafakerGeolocationTest {
 
     try (var ctx = GeneratorContext.enter(factory, "usa")) {
       for (int seed = 0; seed < 10; seed++) {
+        // Each iteration builds a fresh Random on this thread — clear first (see FakerCache).
+        FakerCache.clear();
         Random random = new Random(seed);
         String email = (String) generator.generate(random, emailType);
         emails.add(email);

--- a/generators/src/test/java/com/datagenerator/generators/semantic/DatafakerNewTypesTest.java
+++ b/generators/src/test/java/com/datagenerator/generators/semantic/DatafakerNewTypesTest.java
@@ -255,6 +255,7 @@ class DatafakerNewTypesTest {
 
     try (var ctx = GeneratorContext.enter(factory, "usa")) {
       String color1 = (String) generator.generate(r1, new CustomDatafakerType(TYPE_COLOR));
+      FakerCache.clear();
       String color2 = (String) generator.generate(r2, new CustomDatafakerType(TYPE_COLOR));
       // Different seeds should produce different colors (with high probability)
       assertThat(color1).isNotEqualTo(color2);

--- a/generators/src/test/java/com/datagenerator/generators/semantic/FakerCacheTest.java
+++ b/generators/src/test/java/com/datagenerator/generators/semantic/FakerCacheTest.java
@@ -17,6 +17,7 @@
 package com.datagenerator.generators.semantic;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -130,6 +131,20 @@ class FakerCacheTest {
     String name3 = faker2.name().fullName();
 
     assertThat(name3).isEqualTo(name1); // Same seed = same first value
+  }
+
+  @Test
+  void shouldThrowWhenDifferentRandomUsedForSameThread() {
+    // Regression for issue #261: serving a stale Faker built with a different Random silently
+    // breaks determinism. Must fail fast instead.
+    Random random1 = new Random(1);
+    Random random2 = new Random(2);
+
+    FakerCache.getOrCreate(Locale.ITALY, random1);
+
+    assertThatThrownBy(() -> FakerCache.getOrCreate(Locale.FRANCE, random2))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("different Random");
   }
 
   @Test

--- a/use-cases/ci-pipeline-seeding/expected-fingerprint.txt
+++ b/use-cases/ci-pipeline-seeding/expected-fingerprint.txt
@@ -1,3 +1,3 @@
 customers 100 b642a5c040d4881e4201958198ad6e9c
-orders 400 098aa545e48270ed715c2164fadd2e74
-order_items 1200 570394dba09cae0f47439df4f7a5e370
+orders 400 6da722939a16ed6b3ec4dbce933eaca8
+order_items 1200 95a7c1c2cd28d3f3758bfcccdc5bfa7a


### PR DESCRIPTION
Fixes from a targeted code review (memory leaks, thread-safety, determinism, edge cases). Each commit maps to one issue. Full suite green: `build` + `integrationTest` + `slowTest` (Testcontainers Kafka/DB/File + Schema Registry + Vault).

## Included
- **#254** `IntegerGenerator` infinite loop on int ranges wider than 2^31 → `min + (int) nextLong(range)`.
- **#255** `now`-relative timestamps not reproducible → bounds snapshotted per field.
- **#256** `StructureRegistry` cache `HashMap` → `ConcurrentHashMap` (read/written on worker threads).
- **#257** Kafka producer leak when shutdown `flush()` throws → `close()` in `finally`.
- **#258** Kafka async mode silently dropped records → failures counted + surfaced at `close()`.
- **#259** DB/File destinations leaked resources after a partial `open()` → `close()` releases them.
- **#261** `FakerCache` served a stale-seeded Faker silently → now fails fast.

## ⚠️ Breaking — #260
`decimal[min..max]` now draws from a discrete uniform grid so the inclusive `max` is reachable. **Output changes for a given seed on any `decimal` field** — regenerate golden files/fixtures. Documented in CHANGELOG (Unreleased). Determinism within this version is unchanged.

## Notes
- #258 also made `recordCount` an `AtomicLong` (SpotBugs, shared with the async I/O thread).
- #261's fail-fast exposed pre-existing test sites reusing a thread with a new `Random`; each now calls `FakerCache.clear()` (honors the enforced contract).

Closes #254, #255, #256, #257, #258, #259, #260, #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)