### PR TITLE
chore(deps): batch 5 Dependabot bumps (#264-#268)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Set up JDK 21
-      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Set up JDK 21
-      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Set up JDK 21
-      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Set up JDK 21
-      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/use-case-ci-seeding.yml
+++ b/.github/workflows/use-case-ci-seeding.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up JDK 21
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/core/src/test/java/com/datagenerator/core/structure/StructureRegistryTest.java
+++ b/core/src/test/java/com/datagenerator/core/structure/StructureRegistryTest.java
@@ -192,8 +192,9 @@ class StructureRegistryTest {
     executor.shutdown();
     assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
 
-    assertThat(results).hasSize(threadCount);
-    assertThat(results).allSatisfy(r -> assertThat(r).isEqualTo(results.get(0)));
+    assertThat(results)
+        .hasSize(threadCount)
+        .allSatisfy(r -> assertThat(r).isEqualTo(results.get(0)));
   }
 
   /** Mock loader for testing */

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,7 +51,7 @@ awaitility = "4.3.0"  # Updated from 4.2.2
 aws-sdk = "2.54.6"
 azure-keyvault-secrets = "4.11.2"
 azure-identity = "1.18.5"
-gcp-secretmanager = "2.95.0"
+gcp-secretmanager = "2.96.0"
 
 # Security Constraints (for dependency-check)
 log4j = "2.26.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ testcontainers = "1.21.4"
 awaitility = "4.3.0"  # Updated from 4.2.2
 
 # Security
-aws-sdk = "2.54.1"
+aws-sdk = "2.54.6"
 azure-keyvault-secrets = "4.11.2"
 azure-identity = "1.18.5"
 gcp-secretmanager = "2.95.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,7 @@ log4j = "2.26.1"
 # Build Plugins
 jmh-plugin = "0.7.3"
 lombok-plugin = "9.5.0"
-spotless-plugin = "8.10.0"
+spotless-plugin = "8.10.1"
 spotbugs-plugin = "6.5.11"
 dependency-check-plugin = "13.0.0"
 sonarqube-plugin = "7.4.0.8496"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ awaitility = "4.3.0"  # Updated from 4.2.2
 # Security
 aws-sdk = "2.54.1"
 azure-keyvault-secrets = "4.11.2"
-azure-identity = "1.18.4"
+azure-identity = "1.18.5"
 gcp-secretmanager = "2.95.0"
 
 # Security Constraints (for dependency-check)


### PR DESCRIPTION
Batches five Dependabot PRs into one CI cycle (our usual dep-batching flow).

## Bumps
- `com.azure:azure-identity` 1.18.4 → 1.18.5 (#268)
- `software.amazon.awssdk:secretsmanager` 2.54.1 → 2.54.6 (#266)
- `com.google.cloud:google-cloud-secretmanager` 2.95.0 → 2.96.0 (#264)
- `com.diffplug.spotless` 8.10.0 → 8.10.1 (#265)
- `actions/setup-java` 5.7.0 → 6.0.0 (#267)

Plus: chained two assertions in `StructureRegistryTest` to clear a pre-existing Sonar S5853 (first-scanned since it merged; not a dependency change).

## Verified locally
- `build` (unit + spotless + spotbugs): green
- `integrationTest` + `slowTest` (Testcontainers Kafka/DB/SchemaRegistry/Vault): green
- Sonar: 0 open violations. Gate's only red is `new_coverage` (IT-covered destination code not counted in the unit jacoco report) — a pre-existing main artifact, unrelated to these bumps.

Supersedes #264, #265, #266, #267, #268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)