### PR TITLE
build+test: fix Sonar new-code coverage (jacoco IT aggregation + branch tests)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -248,6 +248,15 @@ subprojects {
 
     tasks.named<JacocoReport>("jacocoTestReport") {
         dependsOn(tasks.test)
+        // Aggregate whatever test exec data is present so integration/slow coverage counts too.
+        // Destination adapters (Kafka/DB/File) and other IT-only paths are exercised by
+        // integrationTest/slowTest, not unit tests; without their exec data the Sonar new-code
+        // coverage undercounts. A plain `build` still reports unit-only coverage (only test.exec
+        // exists); after integrationTest/slowTest run, their exec is included in the report.
+        // mustRunAfter (not dependsOn) keeps this opportunistic: it satisfies Gradle's implicit-
+        // dependency validation for reading their exec output without forcing IT/slow to run.
+        mustRunAfter(tasks.named("integrationTest"), tasks.named("slowTest"))
+        executionData(fileTree(layout.buildDirectory.dir("jacoco")).include("*.exec"))
         reports {
             xml.required.set(true)
             html.required.set(true)

--- a/destinations/src/test/java/com/datagenerator/destinations/database/DatabaseDestinationTest.java
+++ b/destinations/src/test/java/com/datagenerator/destinations/database/DatabaseDestinationTest.java
@@ -582,6 +582,27 @@ class DatabaseDestinationTest {
     verify(mockConn, never()).createStatement();
   }
 
+  @Test
+  void shouldThrowDestinationExceptionWhenTruncateFails() throws Exception {
+    Connection mockConn = mock(Connection.class);
+    DataSource mockDs = mock(DataSource.class);
+    Statement mockTruncateStmt = mock(Statement.class);
+    when(mockDs.getConnection()).thenReturn(mockConn);
+    when(mockConn.createStatement()).thenReturn(mockTruncateStmt);
+    when(mockTruncateStmt.executeUpdate(anyString())).thenThrow(new SQLException("truncate boom"));
+
+    DatabaseDestination dest = new DatabaseDestination(truncateConfig(true), mockDs);
+    dest.open();
+
+    var rec = buildRecord(1, NAME_ALICE, true);
+    assertThatThrownBy(() -> dest.write(rec))
+        .isInstanceOf(DestinationException.class)
+        .hasMessageContaining("Failed to truncate table")
+        .hasMessageContaining(TABLE_USERS);
+
+    dest.close();
+  }
+
   // --- Helpers ---
 
   private int countRows() throws SQLException {

--- a/destinations/src/test/java/com/datagenerator/destinations/file/FileDestinationTest.java
+++ b/destinations/src/test/java/com/datagenerator/destinations/file/FileDestinationTest.java
@@ -25,6 +25,7 @@ import com.datagenerator.formats.csv.CsvSerializer;
 import com.datagenerator.formats.json.JsonSerializer;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -597,5 +598,57 @@ class FileDestinationTest {
     assertThatThrownBy(destination::open)
         .isInstanceOf(DestinationException.class)
         .hasMessageContaining("compress_mode");
+  }
+
+  @Test
+  void shouldRejectPlainWriteWhenPerChunkGzipEnabled() {
+    // write() (the record-object path) is not supported once per_chunk gzip is active — the
+    // engine must route through the serialized/coalesced write path instead.
+    Path outputFile = tempDir.resolve("per_chunk_plain_write.json");
+    FileDestinationConfig config =
+        configBuilder.filePath(outputFile).compress(true).compressMode("per_chunk").build();
+
+    FileDestination destination = new FileDestination(config, new JsonSerializer());
+    destination.open();
+
+    Map<String, Object> row = Map.of("id", 1);
+    try {
+      assertThatThrownBy(() -> destination.write(row))
+          .isInstanceOf(DestinationException.class)
+          .hasMessageContaining("serialized write path");
+    } finally {
+      destination.close();
+    }
+  }
+
+  @Test
+  void shouldGzipPayloadAsIndependentMemberWhenWriteSerializedCalledInPerChunkMode()
+      throws Exception {
+    // Defensive path (issue #210): the engine normally routes per_chunk through
+    // coalesce()/writeSerializedChunk(), but writeSerialized() must still gzip-wrap a single
+    // payload correctly if ever invoked directly.
+    Path outputFile = tempDir.resolve("per_chunk_direct.json");
+    FileDestinationConfig config =
+        configBuilder.filePath(outputFile).compress(true).compressMode("per_chunk").build();
+
+    try (FileDestination destination = new FileDestination(config, new JsonSerializer())) {
+      destination.open();
+      byte[] payload = "{\"id\":99}".getBytes(StandardCharsets.UTF_8);
+      destination.writeSerialized(payload);
+    }
+
+    Path gzFile = Path.of(outputFile.toString() + ".gz");
+    assertThat(gzFile).exists();
+
+    List<String> lines = new ArrayList<>();
+    try (BufferedReader reader =
+        new BufferedReader(
+            new InputStreamReader(new GZIPInputStream(Files.newInputStream(gzFile))))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        lines.add(line);
+      }
+    }
+    assertThat(lines).containsExactly("{\"id\":99}");
   }
 }

--- a/destinations/src/test/java/com/datagenerator/destinations/kafka/KafkaDestinationTest.java
+++ b/destinations/src/test/java/com/datagenerator/destinations/kafka/KafkaDestinationTest.java
@@ -303,6 +303,25 @@ class KafkaDestinationTest {
     verify(mockProducer, times(1)).close();
   }
 
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldLogProgressEveryTenThousandRecords() {
+    // Line ~242: progress logging fires when recordCount % 10000 == 0. Write exactly 10,000
+    // async records so that modulus is hit (and no exception surfaces from the count/log path).
+    Producer<String, byte[]> mockProducer = mock(Producer.class);
+
+    KafkaDestinationConfig config =
+        KafkaDestinationConfig.builder().bootstrap(BOOTSTRAP).topic(TOPIC).sync(false).build();
+
+    KafkaDestination dest = new KafkaDestination(config, new JsonSerializer(), mockProducer);
+
+    for (int i = 0; i < 10_000; i++) {
+      dest.write(Map.of("id", i));
+    }
+
+    verify(mockProducer, times(10_000)).send(any(), any(Callback.class));
+  }
+
   // Note: Integration tests with actual Kafka broker using Testcontainers
   // will be implemented in TASK-023.
 }

--- a/generators/src/test/java/com/datagenerator/generators/primitive/DecimalGeneratorTest.java
+++ b/generators/src/test/java/com/datagenerator/generators/primitive/DecimalGeneratorTest.java
@@ -166,6 +166,25 @@ class DecimalGeneratorTest {
   }
 
   @Test
+  void shouldGenerateWithinRangeWhenGridExceedsLongRange() {
+    // scale=18 over [0, 100] gives steps = 100 * 10^18 = 1e20, whose bitLength (~67) exceeds the
+    // 63-bit threshold, forcing the continuous-interpolation fallback (DecimalGenerator.java:72)
+    // instead of the common long-draw path.
+    PrimitiveType type =
+        new PrimitiveType(
+            PrimitiveType.Kind.DECIMAL, "0.000000000000000000", "100.000000000000000000");
+    Random random = new Random(42L);
+    BigDecimal min = new BigDecimal("0.000000000000000000");
+    BigDecimal max = new BigDecimal("100.000000000000000000");
+
+    for (int i = 0; i < 200; i++) {
+      BigDecimal value = (BigDecimal) generator.generate(random, type);
+      assertThat(value).isBetween(min, max);
+      assertThat(value.scale()).isEqualTo(18);
+    }
+  }
+
+  @Test
   void shouldSupportDecimalKindOnly() {
     assertThat(
             generator.supports(new PrimitiveType(PrimitiveType.Kind.DECIMAL, "0.0", DECIMAL_MAX)))


### PR DESCRIPTION
Fixes the Sonar quality gate's `new_coverage` failure (was 74.3% < 80%) and adds real tests for recent changes.

## Root cause
`jacocoTestReport` aggregated only unit `test.exec`, so code exercised solely by `integrationTest`/`slowTest` (the Kafka/DB/File destination adapters) counted as uncovered.

## Changes
- **build.gradle.kts** — the report now includes every `*.exec` present (`executionData(fileTree(...))`) with `mustRunAfter(integrationTest, slowTest)`. A plain `build` stays unit-only; IT/slow coverage is pulled in only when those tasks run.
- **Tests** for previously-uncovered new-code branches:
  - `DecimalGenerator` huge-grid (scale-18) fallback (#260)
  - `FileDestination` per_chunk gzip write path + plain-write guard (#210)
  - `KafkaDestination` 10k-record progress-log boundary (#258)
  - `DatabaseDestination` truncate-failure → `DestinationException` (#80)

## Result (local Sonar gate — homelab, not in CI)
`new_coverage 74.3% → 85.3%`, gate **OK**, 0 new violations. Full suite (unit + integration + slow) green.

## Note
`FileDestination.closeQuietly` catch/log branches (#259) remain uncovered — the only ways to hit them are `setAccessible` reflection (Codacy-blocked) or a package-private production seam. Left uncovered by design; can add a seam if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)