### PR TITLE
fix(destinations): pin MySQL session zone to UTC for deterministic TIMESTAMP (#218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > fixtures, contract tests — regenerate them. Determinism *within* this version is unchanged: a
 > given seed still yields byte-identical output on any thread count.
 
+> ### ⚠️ MySQL `TIMESTAMP` columns re-normalise to UTC
+>
+> MySQL sessions are now pinned to `time_zone = '+00:00'` on every connection, so `TIMESTAMP`
+> columns store the same instant regardless of the host's zone (see *Fixed*). A job that previously
+> ran against MySQL on a non-UTC machine stored a `TIMESTAMP` value shifted by that machine's
+> session-zone conversion; re-run the job to normalise it. `DATETIME` columns and other database
+> engines are unaffected.
+
 ### Changed
 - **`decimal` generator now reaches its inclusive `max` (#260)** — the old algorithm was
   `min + nextDouble() * (max - min)`, and `nextDouble()` returns `[0.0, 1.0)`, so `max` was
@@ -63,7 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`FakerCache` silently served a stale-seeded `Faker` instead of failing fast (#261)** — on a reused
   thread handed a different `Random` without `FakerCache.clear()`, it logged a warning and kept the
   first job's stale RNG, silently losing reproducibility. It now throws `IllegalStateException`.
-- **Database timestamps were bound in the JVM's default time zone (#80)** — `setTimestamp()` was called without a `Calendar`, so the driver rendered each `Instant` in the local zone before writing it to a `TIMESTAMP` column. The same seed therefore produced different stored wall-clock values on different machines: an instant of `12:00:00Z` landed as `14:00:00` on a CEST developer box and `12:00:00` on a UTC CI runner, breaking the cross-machine reproducibility guarantee for any structure with a `timestamp` field. Timestamps are now bound as a `LocalDateTime` taken at `ZoneOffset.UTC` — a value with no offset, so the driver has nothing to convert and the stored wall clock depends only on the seed. `date` fields were never affected. Verified on PostgreSQL, MySQL, Oracle and SQL Server. Caught by the new CI seeding use case, whose fingerprint differed between a local run and GitHub Actions. Note that zone-aware column types still apply their own conversion: PostgreSQL `timestamptz` and Oracle `TIMESTAMP WITH TIME ZONE` preserve the instant, but MySQL `TIMESTAMP` converts using the connection's session zone and can still drift (#218).
+- **Database timestamps were bound in the JVM's default time zone (#80)** — `setTimestamp()` was called without a `Calendar`, so the driver rendered each `Instant` in the local zone before writing it to a `TIMESTAMP` column. The same seed therefore produced different stored wall-clock values on different machines: an instant of `12:00:00Z` landed as `14:00:00` on a CEST developer box and `12:00:00` on a UTC CI runner, breaking the cross-machine reproducibility guarantee for any structure with a `timestamp` field. Timestamps are now bound as a `LocalDateTime` taken at `ZoneOffset.UTC` — a value with no offset, so the driver has nothing to convert and the stored wall clock depends only on the seed. `date` fields were never affected. Verified on PostgreSQL, MySQL, Oracle and SQL Server. Caught by the new CI seeding use case, whose fingerprint differed between a local run and GitHub Actions. Note that zone-aware column types still apply their own conversion: PostgreSQL `timestamptz` and Oracle `TIMESTAMP WITH TIME ZONE` preserve the instant; MySQL `TIMESTAMP` also converts server-side using the connection's session zone — see #218 below for that fix.
+- **MySQL `TIMESTAMP` columns still drifted despite the client-side UTC binding fix (#218)** — MySQL's `TIMESTAMP` type converts on write using the connection's session `time_zone`, which defaults to `SYSTEM` (the MySQL server host's own OS time zone, not necessarily UTC), so the #80 fix was undone server-side: the same seed stored a different instant depending on how the target MySQL server was configured. `DatabaseDestination.open()` now pins the session zone to UTC on every MySQL connection via Hikari's `connectionInitSql` (`SET time_zone = '+00:00'`), so the server has nothing left to convert. Scoped to `jdbc:mysql:` URLs only — MariaDB and other engines are unaffected.
 
 ### Added
 - **Opt-in table truncation via `truncate_before_insert` (#80)** — database destinations can empty each target table with `TRUNCATE TABLE ... CASCADE` before its first insert, so a fixed seed plus a clean table yields a deterministic dataset with no external teardown script. **DESTRUCTIVE** — default `false`, PostgreSQL/Oracle only.

--- a/destinations/src/main/java/com/datagenerator/destinations/database/DatabaseDestination.java
+++ b/destinations/src/main/java/com/datagenerator/destinations/database/DatabaseDestination.java
@@ -237,6 +237,16 @@ public class DatabaseDestination extends AbstractDestination {
       hikariConfig.setMaximumPoolSize(config.getPoolSize());
       hikariConfig.setAutoCommit(STRATEGY_AUTO_COMMIT.equals(config.getTransactionStrategy()));
 
+      // MySQL converts TIMESTAMP columns on write using the connection's session time_zone, which
+      // defaults to SYSTEM — the MySQL server host's own OS zone, not necessarily UTC — so the same
+      // seed stored different instants depending on how the target server was configured (issue
+      // #218). Pin the session zone to UTC on every pooled connection so the stored instant depends
+      // only on the value, not the server. Offset '+00:00' needs no server time-zone tables. Only
+      // MySQL applies this session conversion.
+      if (config.getJdbcUrl() != null && config.getJdbcUrl().startsWith("jdbc:mysql:")) {
+        hikariConfig.setConnectionInitSql("SET time_zone = '+00:00'");
+      }
+
       dataSource = new HikariDataSource(hikariConfig);
       connection = dataSource.getConnection();
     }

--- a/destinations/src/main/java/com/datagenerator/destinations/database/JdbcTypeMapper.java
+++ b/destinations/src/main/java/com/datagenerator/destinations/database/JdbcTypeMapper.java
@@ -72,9 +72,11 @@ import java.time.ZoneOffset;
  *
  * <p>This governs the value leaving the client. Zone-aware column types still apply their own
  * conversion on top: PostgreSQL {@code timestamptz} and Oracle {@code TIMESTAMP WITH TIME ZONE}
- * preserve the instant, but MySQL {@code TIMESTAMP} converts using the connection's session zone
- * and can still drift — see issue #218. Zone-naive columns ({@code TIMESTAMP}, {@code DATETIME},
- * {@code DATETIME2}) are exact.
+ * preserve the instant. MySQL {@code TIMESTAMP} also converts on write using the connection's
+ * session {@code time_zone} — {@link DatabaseDestination} pins that session zone to UTC on every
+ * MySQL connection ({@code SET time_zone = '+00:00'}, issue #218), so the conversion is a no-op and
+ * the stored instant is deterministic too. Zone-naive columns ({@code DATETIME}, {@code DATETIME2})
+ * are exact regardless.
  *
  * <p><b>Thread Safety:</b> Stateless — all methods are static and every value bound is immutable.
  * Safe for concurrent use.

--- a/destinations/src/test/java/com/datagenerator/destinations/database/DatabaseDestinationMySqlTimestampZoneIT.java
+++ b/destinations/src/test/java/com/datagenerator/destinations/database/DatabaseDestinationMySqlTimestampZoneIT.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 Marco Ferretti
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datagenerator.destinations.database;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datagenerator.destinations.IntegrationTest;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TimeZone;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+/**
+ * Regression test for issue #218: MySQL {@code TIMESTAMP} columns drift because the server converts
+ * the UTC wall clock {@link JdbcTypeMapper} sends on write using the connection's session {@code
+ * time_zone}, and that session zone defaults to {@code SYSTEM} — the MySQL server host's own OS
+ * time zone, which is production-dependent and not guaranteed to be UTC (a self-hosted server or a
+ * developer's local MySQL commonly runs on local time).
+ *
+ * <p>The MySQL container's OS time zone is forced to {@code Pacific/Kiritimati} (UTC+14, no DST —
+ * as far from UTC as a zone gets) via the {@code TZ} container env var, which is what {@code
+ * SYSTEM} resolves to server-side without the fix and is what actually reproduces the drift. The
+ * JVM default zone is forced to the same hostile zone for realism (matching a developer laptop
+ * outside UTC), though the client-side binding is already zone-naive since #80 and does not itself
+ * depend on it. Toggling {@link TimeZone#setDefault(TimeZone)} per-class is safe only because these
+ * integration tests run sequentially (no JUnit parallel execution is configured for this module).
+ *
+ * <p>Unlike {@link AbstractDatabaseDestinationIT}, this test declares a real {@code TIMESTAMP}
+ * column (not {@code DATETIME}) and does <b>not</b> pin {@code connectionTimeZone=UTC} on the JDBC
+ * URL — pinning it there would mask the server-side drift this test exists to catch. It relies
+ * solely on {@link DatabaseDestination#open()} issuing {@code SET time_zone = '+00:00'} via Hikari
+ * {@code connectionInitSql}.
+ *
+ * <p>Verification reads {@code UNIX_TIMESTAMP(issued_at)}, which MySQL always evaluates against the
+ * column's true stored UTC epoch regardless of the reading session's zone — unlike {@code SELECT
+ * issued_at}, which would itself be re-converted on the way out and could coincidentally match.
+ */
+class DatabaseDestinationMySqlTimestampZoneIT extends IntegrationTest {
+
+  private static final String TABLE_NAME = "ts_probe";
+  private static final Instant ISSUED_AT = Instant.parse("2024-06-15T10:30:00Z");
+  private static final long EXPECTED_EPOCH_SECONDS = 1718447400L;
+
+  private static TimeZone originalDefaultZone;
+
+  @Container
+  static MySQLContainer<?> mysql =
+      new MySQLContainer<>("mysql:8.4")
+          .withDatabaseName("testdb")
+          .withUsername("testuser")
+          .withPassword("testpass")
+          .withEnv("TZ", "Pacific/Kiritimati");
+
+  private Connection verifyConnection;
+
+  @BeforeAll
+  static void pinHostileJvmZoneForRealism() {
+    originalDefaultZone = TimeZone.getDefault();
+    TimeZone.setDefault(TimeZone.getTimeZone("Pacific/Kiritimati"));
+  }
+
+  @AfterAll
+  static void restoreJvmZone() {
+    TimeZone.setDefault(originalDefaultZone);
+  }
+
+  @BeforeEach
+  void setUp() throws Exception {
+    // Deliberately NOT adding connectionTimeZone=UTC here — see class javadoc.
+    verifyConnection =
+        DriverManager.getConnection(mysql.getJdbcUrl(), mysql.getUsername(), mysql.getPassword());
+    try (Statement st = verifyConnection.createStatement()) {
+      st.execute("CREATE TABLE " + TABLE_NAME + " (issued_at TIMESTAMP NULL)");
+    }
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    try (Statement st = verifyConnection.createStatement()) {
+      st.execute("DROP TABLE IF EXISTS " + TABLE_NAME);
+    }
+    verifyConnection.close();
+  }
+
+  @Test
+  void shouldStoreMySqlTimestampAsTrueUtcEpochUnderHostileServerZone() throws Exception {
+    DatabaseDestinationConfig config =
+        DatabaseDestinationConfig.builder()
+            .jdbcUrl(mysql.getJdbcUrl())
+            .username(mysql.getUsername())
+            .password(mysql.getPassword())
+            .tableName(TABLE_NAME)
+            .batchSize(1)
+            .build();
+
+    Map<String, Object> row = new LinkedHashMap<>();
+    row.put("issued_at", ISSUED_AT);
+
+    try (DatabaseDestination dest = new DatabaseDestination(config)) {
+      dest.open();
+      dest.write(row);
+      dest.flush();
+    }
+
+    try (Statement st = verifyConnection.createStatement();
+        ResultSet rs = st.executeQuery("SELECT UNIX_TIMESTAMP(issued_at) FROM " + TABLE_NAME)) {
+      assertThat(rs.next()).isTrue();
+      assertThat(rs.getLong(1)).isEqualTo(EXPECTED_EPOCH_SECONDS);
+    }
+  }
+}


### PR DESCRIPTION
Fixes #218 — MySQL `TIMESTAMP` columns drifted with the zone despite the client-side UTC binding (#80).

## Root cause
MySQL converts `TIMESTAMP` on write using the connection's session `time_zone`, which defaults to `SYSTEM` — **the MySQL server host's own OS zone**, not necessarily UTC. (The issue's stated JVM-derivation mechanism was empirically disproved with Connector/J 26.7.0; the real vector is the server's `SYSTEM` zone.) So `#80`'s fix was undone server-side: the same seed stored a different instant depending on the target server's configuration.

## Fix
`DatabaseDestination.open()` sets `SET time_zone = '+00:00'` as Hikari `connectionInitSql` for `jdbc:mysql:` connections, pinning the session zone to UTC on every pooled connection. Offset `+00:00` needs no server time-zone tables. Scoped to `jdbc:mysql:` only — MariaDB/others unaffected.

## Test
`DatabaseDestinationMySqlTimestampZoneIT`: a real `TIMESTAMP` column, container OS zone forced to `Pacific/Kiritimati` (UTC+14), writes `2024-06-15T10:30:00Z` and asserts `SELECT UNIX_TIMESTAMP(issued_at) == 1718447400`. Confirmed to fail without the fix (14h off) and pass with it.

Also: `JdbcTypeMapper` javadoc reconciled; CHANGELOG breaking-change blockquote + `### Fixed` bullet, and corrected #80's dangling #218 reference.

## ⚠️ Breaking
Stored MySQL `TIMESTAMP` instants re-normalise to UTC — a job that previously ran against a non-UTC MySQL server stored zone-shifted values; re-run to normalise. `DATETIME` and other engines unaffected.

## Verified locally
Full `build` (unit + spotbugs + spotless), all `integrationTest` + `slowTest` (incl. the new MySQL IT), and Sonar gate **OK** (new_coverage 85.2%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)